### PR TITLE
Social domain

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,5 +35,8 @@ out/
 
 ### VS Code ###
 .vscode/
+
+### ADDITIONAL ###
 application*.yml
 memo/*
+/src/main/generated/

--- a/build.gradle
+++ b/build.gradle
@@ -23,6 +23,10 @@ repositories {
     mavenCentral()
 }
 
+ext {
+    set('snippetsDir', file("build/generated-snippets"))
+}
+
 dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     implementation 'org.springframework.boot:spring-boot-starter-validation'
@@ -37,6 +41,12 @@ dependencies {
     runtimeOnly "io.jsonwebtoken:jjwt-impl:0.12.3"
     runtimeOnly "io.jsonwebtoken:jjwt-jackson:0.12.3"
 
+    // QueryDSL
+    implementation 'com.querydsl:querydsl-jpa:5.0.0:jakarta'
+    annotationProcessor "com.querydsl:querydsl-apt:${dependencyManagement.importedProperties['querydsl.version']}:jakarta"
+    annotationProcessor "jakarta.annotation:jakarta.annotation-api"
+    annotationProcessor "jakarta.persistence:jakarta.persistence-api"
+
     // lombok
     compileOnly 'org.projectlombok:lombok'
     annotationProcessor 'org.projectlombok:lombok'
@@ -50,6 +60,10 @@ dependencies {
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testImplementation 'org.springframework.security:spring-security-test'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+}
+
+clean {
+    delete file('src/main/generated')
 }
 
 tasks.named('test') {

--- a/src/main/java/com/maruhxn/todomon/domain/member/dao/MemberQueryRepository.java
+++ b/src/main/java/com/maruhxn/todomon/domain/member/dao/MemberQueryRepository.java
@@ -1,15 +1,20 @@
 package com.maruhxn.todomon.domain.member.dao;
 
 import com.maruhxn.todomon.domain.social.dto.response.DiligenceRankItem;
+import com.maruhxn.todomon.domain.social.dto.response.TodoAchievementRankItem;
 import com.querydsl.core.types.Projections;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
 
+import java.time.DayOfWeek;
+import java.time.LocalDate;
+import java.time.temporal.TemporalAdjusters;
 import java.util.List;
 
 import static com.maruhxn.todomon.domain.member.domain.QDiligence.diligence;
 import static com.maruhxn.todomon.domain.member.domain.QMember.member;
+import static com.maruhxn.todomon.domain.todo.domain.QTodoAchievementHistory.todoAchievementHistory;
 
 @Repository
 @RequiredArgsConstructor
@@ -29,6 +34,48 @@ public class MemberQueryRepository {
                 .from(member)
                 .join(member.diligence, diligence)
                 .orderBy(diligence.level.desc(), diligence.gauge.desc(), member.createdAt.asc())
+                .limit(10)
+                .fetch();
+    }
+
+    public List<TodoAchievementRankItem> findTop10MembersByYesterdayAchievement() {
+        LocalDate yesterday = LocalDate.now().minusDays(1);
+
+        return query.select(
+                        Projections.fields(TodoAchievementRankItem.class,
+                                member.id,
+                                member.username,
+                                member.profileImageUrl,
+                                todoAchievementHistory.cnt
+                        )
+                )
+                .from(todoAchievementHistory)
+                .join(todoAchievementHistory.member, member)
+                .where(todoAchievementHistory.date.eq(yesterday))
+                .groupBy(member.id)
+                .orderBy(todoAchievementHistory.cnt.sum().desc(), todoAchievementHistory.createdAt.max().desc(), member.createdAt.asc())
+                .limit(10)
+                .fetch();
+    }
+
+    public List<TodoAchievementRankItem> findTop10MembersByWeeklyAchievement() {
+        LocalDate startOfCurrentWeek = LocalDate.now().with(TemporalAdjusters.previousOrSame(DayOfWeek.MONDAY));
+        LocalDate startOfLastWeek = startOfCurrentWeek.minusWeeks(1);
+        LocalDate endOfLastWeek = startOfCurrentWeek.minusDays(1);
+
+        return query.select(
+                        Projections.fields(TodoAchievementRankItem.class,
+                                member.id,
+                                member.username,
+                                member.profileImageUrl,
+                                todoAchievementHistory.cnt
+                        )
+                )
+                .from(todoAchievementHistory)
+                .join(todoAchievementHistory.member, member)
+                .where(todoAchievementHistory.date.between(startOfLastWeek, endOfLastWeek))
+                .groupBy(member.id)
+                .orderBy(todoAchievementHistory.cnt.sum().desc(), todoAchievementHistory.createdAt.max().desc(), member.createdAt.asc())
                 .limit(10)
                 .fetch();
     }

--- a/src/main/java/com/maruhxn/todomon/domain/member/dao/MemberQueryRepository.java
+++ b/src/main/java/com/maruhxn/todomon/domain/member/dao/MemberQueryRepository.java
@@ -53,7 +53,7 @@ public class MemberQueryRepository {
                 .join(todoAchievementHistory.member, member)
                 .where(todoAchievementHistory.date.eq(yesterday))
                 .groupBy(member.id)
-                .orderBy(todoAchievementHistory.cnt.sum().desc(), todoAchievementHistory.createdAt.max().desc(), member.createdAt.asc())
+                .orderBy(todoAchievementHistory.cnt.sum().desc(), todoAchievementHistory.createdAt.max().asc(), member.createdAt.asc())
                 .limit(10)
                 .fetch();
     }
@@ -75,7 +75,7 @@ public class MemberQueryRepository {
                 .join(todoAchievementHistory.member, member)
                 .where(todoAchievementHistory.date.between(startOfLastWeek, endOfLastWeek))
                 .groupBy(member.id)
-                .orderBy(todoAchievementHistory.cnt.sum().desc(), todoAchievementHistory.createdAt.max().desc(), member.createdAt.asc())
+                .orderBy(todoAchievementHistory.cnt.sum().desc(), todoAchievementHistory.createdAt.max().asc(), member.createdAt.asc())
                 .limit(10)
                 .fetch();
     }

--- a/src/main/java/com/maruhxn/todomon/domain/member/dao/MemberQueryRepository.java
+++ b/src/main/java/com/maruhxn/todomon/domain/member/dao/MemberQueryRepository.java
@@ -1,0 +1,35 @@
+package com.maruhxn.todomon.domain.member.dao;
+
+import com.maruhxn.todomon.domain.social.dto.response.DiligenceRankItem;
+import com.querydsl.core.types.Projections;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+import static com.maruhxn.todomon.domain.member.domain.QDiligence.diligence;
+import static com.maruhxn.todomon.domain.member.domain.QMember.member;
+
+@Repository
+@RequiredArgsConstructor
+public class MemberQueryRepository {
+
+    private final JPAQueryFactory query;
+
+    public List<DiligenceRankItem> findTop10MembersByDiligenceLevelAndGauge() {
+        return query.select(
+                        Projections.fields(DiligenceRankItem.class,
+                                member.id,
+                                member.username,
+                                member.profileImageUrl,
+                                diligence.level
+                        )
+                )
+                .from(member)
+                .join(member.diligence, diligence)
+                .orderBy(diligence.level.desc(), diligence.gauge.desc(), member.createdAt.asc())
+                .limit(10)
+                .fetch();
+    }
+}

--- a/src/main/java/com/maruhxn/todomon/domain/member/dao/MemberRepository.java
+++ b/src/main/java/com/maruhxn/todomon/domain/member/dao/MemberRepository.java
@@ -1,11 +1,20 @@
 package com.maruhxn.todomon.domain.member.dao;
 
 import com.maruhxn.todomon.domain.member.domain.Member;
+import jakarta.persistence.LockModeType;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Lock;
+import org.springframework.data.jpa.repository.Query;
 
+import java.util.List;
 import java.util.Optional;
 
 public interface MemberRepository extends JpaRepository<Member, Long> {
+
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    @Query("SELECT m FROM Member m")
+    List<Member> findAllWithLock();
+
     Optional<Member> findByEmail(String email);
 
     Boolean existsByUsername(String username);

--- a/src/main/java/com/maruhxn/todomon/domain/member/domain/Diligence.java
+++ b/src/main/java/com/maruhxn/todomon/domain/member/domain/Diligence.java
@@ -25,10 +25,14 @@ public class Diligence extends BaseEntity {
         this.member = member;
     }
 
+    public void levelUp(int level) {
+        this.level += level;
+    }
+
     public void increaseGauge(double gauge) {
         this.gauge += gauge;
         while (this.gauge >= 100) { // 게이지가 100 이상이 될 경우, 레벨이 증가한다.
-            this.level++;
+            levelUp(1);
             this.gauge -= 100;
         }
     }

--- a/src/main/java/com/maruhxn/todomon/domain/member/domain/Member.java
+++ b/src/main/java/com/maruhxn/todomon/domain/member/domain/Member.java
@@ -2,6 +2,7 @@ package com.maruhxn.todomon.domain.member.domain;
 
 import com.maruhxn.todomon.domain.pet.domain.CollectedPet;
 import com.maruhxn.todomon.domain.pet.domain.Pet;
+import com.maruhxn.todomon.domain.social.domain.Follow;
 import com.maruhxn.todomon.global.auth.model.Role;
 import com.maruhxn.todomon.global.auth.model.provider.OAuth2Provider;
 import com.maruhxn.todomon.global.auth.model.provider.OAuth2ProviderUser;
@@ -56,11 +57,19 @@ public class Member extends BaseEntity {
     @OneToOne(mappedBy = "member", cascade = CascadeType.ALL, orphanRemoval = true)
     private Diligence diligence;
 
-    @OneToMany(mappedBy = "member", cascade = CascadeType.ALL)
+    @OneToMany(mappedBy = "member", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<Pet> pets = new ArrayList<>();
 
-    @OneToMany(mappedBy = "member", cascade = CascadeType.ALL)
+    @OneToMany(mappedBy = "member", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<CollectedPet> collectedPets = new ArrayList<>();
+
+    // 팔로워
+    @OneToMany(mappedBy = "followee", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<Follow> followers = new ArrayList<>();
+
+    // 팔로잉
+    @OneToMany(mappedBy = "follower", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<Follow> followings = new ArrayList<>();
 
     @Builder
     public Member(String username, String email, OAuth2Provider provider, String providerId, String profileImageUrl, Role role) {

--- a/src/main/java/com/maruhxn/todomon/domain/member/domain/Member.java
+++ b/src/main/java/com/maruhxn/todomon/domain/member/domain/Member.java
@@ -50,6 +50,9 @@ public class Member extends BaseEntity {
     private Long scheduledReward = 0L;
 
     @ColumnDefault("0")
+    private Long dailyAchievementCnt = 0L;
+
+    @ColumnDefault("0")
     private Long foodCnt = 0L;
 
     @ColumnDefault("0")
@@ -138,5 +141,13 @@ public class Member extends BaseEntity {
     public void addCollection(CollectedPet collectedPet) {
         this.collectedPets.add(collectedPet);
         collectedPet.setMember(this);
+    }
+
+    public void addDailyAchievementCnt(int cnt) {
+        this.dailyAchievementCnt += cnt;
+    }
+
+    public void resetDailyAchievement() {
+        this.dailyAchievementCnt = 0L;
     }
 }

--- a/src/main/java/com/maruhxn/todomon/domain/member/domain/Member.java
+++ b/src/main/java/com/maruhxn/todomon/domain/member/domain/Member.java
@@ -3,6 +3,7 @@ package com.maruhxn.todomon.domain.member.domain;
 import com.maruhxn.todomon.domain.pet.domain.CollectedPet;
 import com.maruhxn.todomon.domain.pet.domain.Pet;
 import com.maruhxn.todomon.domain.social.domain.Follow;
+import com.maruhxn.todomon.domain.social.domain.StarTransaction;
 import com.maruhxn.todomon.global.auth.model.Role;
 import com.maruhxn.todomon.global.auth.model.provider.OAuth2Provider;
 import com.maruhxn.todomon.global.auth.model.provider.OAuth2ProviderUser;
@@ -71,6 +72,14 @@ public class Member extends BaseEntity {
     @OneToMany(mappedBy = "follower", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<Follow> followings = new ArrayList<>();
 
+    // 보낸 star
+    @OneToMany(mappedBy = "sender", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<StarTransaction> sentStars;
+
+    // 받은 star
+    @OneToMany(mappedBy = "receiver", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<StarTransaction> receivedStars;
+
     @Builder
     public Member(String username, String email, OAuth2Provider provider, String providerId, String profileImageUrl, Role role) {
         this.username = username;
@@ -114,6 +123,10 @@ public class Member extends BaseEntity {
 
     public void decreaseFoodCnt(int foodCnt) {
         this.foodCnt -= foodCnt;
+    }
+
+    public void addStar(int starCnt) {
+        this.starPoint += starCnt;
     }
 
     /* 연관관계 메서드 */

--- a/src/main/java/com/maruhxn/todomon/domain/member/domain/Member.java
+++ b/src/main/java/com/maruhxn/todomon/domain/member/domain/Member.java
@@ -134,4 +134,9 @@ public class Member extends BaseEntity {
         this.pets.add(pet);
         pet.setOwner(this);
     }
+
+    public void addCollection(CollectedPet collectedPet) {
+        this.collectedPets.add(collectedPet);
+        collectedPet.setMember(this);
+    }
 }

--- a/src/main/java/com/maruhxn/todomon/domain/member/domain/Member.java
+++ b/src/main/java/com/maruhxn/todomon/domain/member/domain/Member.java
@@ -4,6 +4,7 @@ import com.maruhxn.todomon.domain.pet.domain.CollectedPet;
 import com.maruhxn.todomon.domain.pet.domain.Pet;
 import com.maruhxn.todomon.domain.social.domain.Follow;
 import com.maruhxn.todomon.domain.social.domain.StarTransaction;
+import com.maruhxn.todomon.domain.todo.domain.TodoAchievementHistory;
 import com.maruhxn.todomon.global.auth.model.Role;
 import com.maruhxn.todomon.global.auth.model.provider.OAuth2Provider;
 import com.maruhxn.todomon.global.auth.model.provider.OAuth2ProviderUser;
@@ -82,6 +83,9 @@ public class Member extends BaseEntity {
     // 받은 star
     @OneToMany(mappedBy = "receiver", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<StarTransaction> receivedStars;
+
+    @OneToMany(mappedBy = "member", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<TodoAchievementHistory> todoAchievementHistories;
 
     @Builder
     public Member(String username, String email, OAuth2Provider provider, String providerId, String profileImageUrl, Role role) {

--- a/src/main/java/com/maruhxn/todomon/domain/pet/application/PetService.java
+++ b/src/main/java/com/maruhxn/todomon/domain/pet/application/PetService.java
@@ -47,12 +47,8 @@ public class PetService {
                             /* 아무 작업도 수행 X */
                         },
                         () -> {
-                            CollectedPet collectedPet = CollectedPet.builder()
-                                    .rarity(pet.getRarity())
-                                    .petType(pet.getPetType())
-                                    .evolutionCnt(pet.getEvolutionCnt())
-                                    .build();
-                            collectedPet.setMember(member);
+                            CollectedPet collectedPet = CollectedPet.of(pet);
+                            member.addCollection(collectedPet);
                             collectedPetRepository.save(collectedPet);
                         }
                 );

--- a/src/main/java/com/maruhxn/todomon/domain/pet/dao/CollectedPetQueryRepository.java
+++ b/src/main/java/com/maruhxn/todomon/domain/pet/dao/CollectedPetQueryRepository.java
@@ -1,0 +1,39 @@
+package com.maruhxn.todomon.domain.pet.dao;
+
+import com.maruhxn.todomon.domain.social.dto.response.CollectedPetRankItem;
+import com.querydsl.core.types.Projections;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+import static com.maruhxn.todomon.domain.member.domain.QMember.member;
+import static com.maruhxn.todomon.domain.pet.domain.QCollectedPet.collectedPet;
+
+@Repository
+@RequiredArgsConstructor
+public class CollectedPetQueryRepository {
+
+    private final JPAQueryFactory query;
+
+
+    public List<CollectedPetRankItem> findTop10MembersByCollectedPetCnt() {
+        return query.select(
+                        Projections.fields(CollectedPetRankItem.class,
+                                member.id,
+                                member.username,
+                                member.profileImageUrl,
+                                collectedPet.id.count().intValue().as("petCnt"),
+                                collectedPet.createdAt.max().as("lastCollectedAt")
+                        )
+                )
+                .from(member)
+                .leftJoin(member.collectedPets, collectedPet)
+                .groupBy(member.id, member.username, member.profileImageUrl)
+                .orderBy(collectedPet.id.count().desc(), collectedPet.createdAt.max().desc(), member.createdAt.asc())
+                .limit(10)
+                .fetch();
+    }
+
+}

--- a/src/main/java/com/maruhxn/todomon/domain/pet/domain/CollectedPet.java
+++ b/src/main/java/com/maruhxn/todomon/domain/pet/domain/CollectedPet.java
@@ -36,8 +36,15 @@ public class CollectedPet extends BaseEntity {
         this.appearance = petType.getEvolutionStage(evolutionCnt).getForm();
     }
 
+    public static CollectedPet of(Pet pet) {
+        return CollectedPet.builder()
+                .rarity(pet.getRarity())
+                .evolutionCnt(pet.getEvolutionCnt())
+                .petType(pet.getPetType())
+                .build();
+    }
+
     public void setMember(Member member) {
         this.member = member;
-        member.getCollectedPets().add(this);
     }
 }

--- a/src/main/java/com/maruhxn/todomon/domain/social/api/FollowController.java
+++ b/src/main/java/com/maruhxn/todomon/domain/social/api/FollowController.java
@@ -2,6 +2,7 @@ package com.maruhxn.todomon.domain.social.api;
 
 import com.maruhxn.todomon.domain.social.application.FollowQueryService;
 import com.maruhxn.todomon.domain.social.application.FollowService;
+import com.maruhxn.todomon.domain.social.application.StarService;
 import com.maruhxn.todomon.domain.social.dto.response.FollowItem;
 import com.maruhxn.todomon.global.auth.model.TodomonOAuth2User;
 import com.maruhxn.todomon.global.common.dto.response.DataResponse;
@@ -13,12 +14,13 @@ import org.springframework.web.bind.annotation.*;
 import java.util.List;
 
 @RestController
-@RequestMapping("/api/social")
+@RequestMapping("/api/social/follow")
 @RequiredArgsConstructor
 public class FollowController {
 
     private final FollowService followService;
     private final FollowQueryService followQueryService;
+    private final StarService starService;
 
     @PostMapping("/follow/{memberId}")
     @ResponseStatus(HttpStatus.CREATED)
@@ -26,7 +28,7 @@ public class FollowController {
             @AuthenticationPrincipal TodomonOAuth2User todomonOAuth2User,
             @PathVariable("memberId") Long memberId
     ) {
-        followService.sendFollowRequest(todomonOAuth2User.getId(), memberId);
+        followService.sendFollowRequest(todomonOAuth2User.getMember(), memberId);
     }
 
     @DeleteMapping("/follow/{memberId}")
@@ -35,7 +37,7 @@ public class FollowController {
             @AuthenticationPrincipal TodomonOAuth2User todomonOAuth2User,
             @PathVariable("memberId") Long memberId
     ) {
-        followService.unfollow(todomonOAuth2User.getId(), memberId);
+        followService.unfollow(todomonOAuth2User.getMember(), memberId);
     }
 
     @GetMapping("/{memberId}/followers")

--- a/src/main/java/com/maruhxn/todomon/domain/social/api/FollowController.java
+++ b/src/main/java/com/maruhxn/todomon/domain/social/api/FollowController.java
@@ -1,0 +1,54 @@
+package com.maruhxn.todomon.domain.social.api;
+
+import com.maruhxn.todomon.domain.social.application.FollowQueryService;
+import com.maruhxn.todomon.domain.social.application.FollowService;
+import com.maruhxn.todomon.domain.social.dto.response.FollowItem;
+import com.maruhxn.todomon.global.auth.model.TodomonOAuth2User;
+import com.maruhxn.todomon.global.common.dto.response.DataResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/social")
+@RequiredArgsConstructor
+public class FollowController {
+
+    private final FollowService followService;
+    private final FollowQueryService followQueryService;
+
+    @PostMapping("/follow/{memberId}")
+    @ResponseStatus(HttpStatus.CREATED)
+    public void follow(
+            @AuthenticationPrincipal TodomonOAuth2User todomonOAuth2User,
+            @PathVariable("memberId") Long memberId
+    ) {
+        followService.sendFollowRequest(todomonOAuth2User.getId(), memberId);
+    }
+
+    @DeleteMapping("/follow/{memberId}")
+    @ResponseStatus(HttpStatus.NO_CONTENT)
+    public void unfollow(
+            @AuthenticationPrincipal TodomonOAuth2User todomonOAuth2User,
+            @PathVariable("memberId") Long memberId
+    ) {
+        followService.unfollow(todomonOAuth2User.getId(), memberId);
+    }
+
+    @GetMapping("/{memberId}/followers")
+    public DataResponse<List<FollowItem>> getFollowers(
+            @PathVariable("memberId") Long memberId
+    ) {
+        return DataResponse.of("팔로워 리스트 조회 성공", followQueryService.followerList(memberId));
+    }
+
+    @GetMapping("/{memberId}/followings")
+    public DataResponse<List<FollowItem>> getFollowings(
+            @PathVariable("memberId") Long memberId
+    ) {
+        return DataResponse.of("팔로잉 리스트 조회 성공", followQueryService.followingList(memberId));
+    }
+}

--- a/src/main/java/com/maruhxn/todomon/domain/social/api/OverallRankController.java
+++ b/src/main/java/com/maruhxn/todomon/domain/social/api/OverallRankController.java
@@ -1,0 +1,41 @@
+package com.maruhxn.todomon.domain.social.api;
+
+import com.maruhxn.todomon.domain.social.application.OverallRankQueryService;
+import com.maruhxn.todomon.global.common.dto.response.DataResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+// 팔로우 된 친구들 간 순위 확인
+@RestController
+@RequestMapping("/api/overall/rank")
+@RequiredArgsConstructor
+public class OverallRankController {
+
+    private final OverallRankQueryService overallRankQueryService;
+
+    // 전체 일간 랭킹(가장 많은 업적 달성)
+    @GetMapping("/achievement/daily")
+    public DataResponse<Object> getOverallRankingOfDailyAchievement() {
+        return DataResponse.of("전체 일간 투두 달성 랭킹 조회 성공", overallRankQueryService.getRankingOfDailyAchievement());
+    }
+
+    // 전체 주간 랭킹(가장 많은 업적 달성)
+    @GetMapping("/achievement/weekly")
+    public DataResponse<Object> getOverallRankingOfWeeklyAchievement() {
+        return DataResponse.of("전체 주간 투두 달성 랭킹 조회 성공", overallRankQueryService.getRankingOfWeeklyAchievement());
+    }
+
+    // 전체 일관성 레벨 랭킹 조회
+    @GetMapping("/diligence")
+    public DataResponse<Object> getOverallRankingOfDiligence() {
+        return DataResponse.of("전체 일관성 레벨 랭킹 조회 성공", overallRankQueryService.getTop10MembersByDiligenceLevelAndGauge());
+    }
+
+    // 전체 도감 랭킹 조회 (획득한 펫의 수)
+    @GetMapping("/collection")
+    public DataResponse<Object> getOverallRankingOfCollection() {
+        return DataResponse.of("전체 도감 랭킹 조회 성공", overallRankQueryService.getTop10MembersByCollectedPetCnt());
+    }
+}

--- a/src/main/java/com/maruhxn/todomon/domain/social/api/SocialRankController.java
+++ b/src/main/java/com/maruhxn/todomon/domain/social/api/SocialRankController.java
@@ -1,0 +1,67 @@
+package com.maruhxn.todomon.domain.social.api;
+
+
+import com.maruhxn.todomon.domain.social.application.SocialRankQueryService;
+import com.maruhxn.todomon.domain.social.dto.response.CollectedPetRankItem;
+import com.maruhxn.todomon.domain.social.dto.response.DiligenceRankItem;
+import com.maruhxn.todomon.domain.social.dto.response.TodoAchievementRankItem;
+import com.maruhxn.todomon.global.auth.model.TodomonOAuth2User;
+import com.maruhxn.todomon.global.common.dto.response.DataResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/social/rank")
+@RequiredArgsConstructor
+public class SocialRankController {
+
+    private final SocialRankQueryService socialRankQueryService;
+
+    @GetMapping("/achievement/daily")
+    public DataResponse<List<TodoAchievementRankItem>> getSocialRankingOfDailyAchievement(
+            @AuthenticationPrincipal TodomonOAuth2User todomonOAuth2User
+    ) {
+        return DataResponse.of(
+                "소셜 일간 투두 달성 랭킹 조회 성공",
+                socialRankQueryService.getSocialRankingOfDailyAchievement(todomonOAuth2User.getMember())
+        );
+    }
+
+    // 소셜 주간 랭킹(가장 많은 업적 달성)
+    @GetMapping("/achievement/weekly")
+    public DataResponse<List<TodoAchievementRankItem>> getSocialRankingOfWeeklyAchievement(
+            @AuthenticationPrincipal TodomonOAuth2User todomonOAuth2User
+    ) {
+        return DataResponse.of(
+                "소셜 주간 투두 달성 랭킹 조회 성공",
+                socialRankQueryService.getSocialRankingOfWeeklyAchievement(todomonOAuth2User.getMember())
+        );
+    }
+
+    // 소셜 일관성 레벨 랭킹 조회
+    @GetMapping("/diligence")
+    public DataResponse<List<DiligenceRankItem>> getSocialRankingOfDiligence(
+            @AuthenticationPrincipal TodomonOAuth2User todomonOAuth2User
+    ) {
+        return DataResponse.of(
+                "소셜 일관성 레벨 랭킹 조회 성공",
+                socialRankQueryService.getSocialRankingOfDiligence(todomonOAuth2User.getMember())
+        );
+    }
+
+    // 소셜 도감 랭킹 조회 (획득한 펫의 수)
+    @GetMapping("/collection")
+    public DataResponse<List<CollectedPetRankItem>> getSocialRankingOfCollection(
+            @AuthenticationPrincipal TodomonOAuth2User todomonOAuth2User
+    ) {
+        return DataResponse.of(
+                "소셜 도감 랭킹 조회 성공",
+                socialRankQueryService.getSocialRankingOfCollection(todomonOAuth2User.getMember())
+        );
+    }
+}

--- a/src/main/java/com/maruhxn/todomon/domain/social/api/StarController.java
+++ b/src/main/java/com/maruhxn/todomon/domain/social/api/StarController.java
@@ -1,0 +1,39 @@
+package com.maruhxn.todomon.domain.social.api;
+
+import com.maruhxn.todomon.domain.social.application.StarService;
+import com.maruhxn.todomon.global.auth.model.TodomonOAuth2User;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/api/social/stars")
+@RequiredArgsConstructor
+public class StarController {
+
+    private final StarService starService;
+
+    // 내가 팔로우하고 있는 사람에게 별을 보낼 수 있다.
+    @PostMapping("/send/{memberId}")
+    public void sendStar(
+            @AuthenticationPrincipal TodomonOAuth2User todomonOAuth2User,
+            @PathVariable("memberId") Long memberId
+    ) {
+        starService.sendStar(todomonOAuth2User.getMember(), memberId);
+    }
+
+    @PatchMapping("/receive/{transactionId}")
+    public void receiveStar(
+            @AuthenticationPrincipal TodomonOAuth2User todomonOAuth2User,
+            @PathVariable("transactionId") Long transactionId
+    ) {
+        starService.receiveOneStar(todomonOAuth2User.getMember(), transactionId);
+    }
+
+    @PatchMapping("/receiveAll")
+    public void receiveAllStars(
+            @AuthenticationPrincipal TodomonOAuth2User todomonOAuth2User
+    ) {
+        starService.receiveAllStars(todomonOAuth2User.getMember());
+    }
+}

--- a/src/main/java/com/maruhxn/todomon/domain/social/application/FollowQueryService.java
+++ b/src/main/java/com/maruhxn/todomon/domain/social/application/FollowQueryService.java
@@ -1,0 +1,61 @@
+package com.maruhxn.todomon.domain.social.application;
+
+import com.maruhxn.todomon.domain.member.dao.MemberRepository;
+import com.maruhxn.todomon.domain.member.domain.Member;
+import com.maruhxn.todomon.domain.social.dao.FollowRepository;
+import com.maruhxn.todomon.domain.social.domain.Follow;
+import com.maruhxn.todomon.domain.social.dto.response.FollowItem;
+import com.maruhxn.todomon.global.error.ErrorCode;
+import com.maruhxn.todomon.global.error.exception.NotFoundException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+import static com.maruhxn.todomon.domain.social.domain.FollowRequestStatus.ACCEPTED;
+import static com.maruhxn.todomon.domain.social.domain.FollowRequestStatus.PENDING;
+
+@Service
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+public class FollowQueryService {
+
+    private final MemberRepository memberRepository;
+    private final FollowRepository followRepository;
+
+    // 팔로우 요청들을 조회한다.
+    public List<FollowItem> getPendingFollowRequests(Member member) {
+        List<Follow> pendingRequests = followRepository.findByFolloweeAndStatusOrderByCreatedAtDesc(member, PENDING);
+        List<Member> pendingFollowerList = pendingRequests.stream()
+                .map(Follow::getFollower)
+                .toList();
+        return pendingFollowerList.stream().map(FollowItem::of).toList();
+    }
+
+    public List<FollowItem> followingList(Long memberId) {
+        Member findMember = memberRepository.findById(memberId)
+                .orElseThrow(() -> new NotFoundException(ErrorCode.NOT_FOUND_MEMBER));
+
+        List<Follow> followings = followRepository.findByFollowerAndStatusOrderByCreatedAtDesc(findMember, ACCEPTED);
+
+        List<Member> followingList = followings.stream()
+                .map(Follow::getFollowee)
+                .toList();
+
+        return followingList.stream().map(FollowItem::of).toList();
+    }
+
+    public List<FollowItem> followerList(Long memberId) {
+        Member findMember = memberRepository.findById(memberId)
+                .orElseThrow(() -> new NotFoundException(ErrorCode.NOT_FOUND_MEMBER));
+
+        List<Follow> followers = followRepository.findByFolloweeAndStatusOrderByCreatedAtDesc(findMember, ACCEPTED);
+
+        List<Member> followerList = followers.stream()
+                .map(Follow::getFollower)
+                .toList();
+
+        return followerList.stream().map(FollowItem::of).toList();
+    }
+}

--- a/src/main/java/com/maruhxn/todomon/domain/social/application/FollowService.java
+++ b/src/main/java/com/maruhxn/todomon/domain/social/application/FollowService.java
@@ -6,6 +6,7 @@ import com.maruhxn.todomon.domain.social.dao.FollowRepository;
 import com.maruhxn.todomon.domain.social.domain.Follow;
 import com.maruhxn.todomon.global.error.ErrorCode;
 import com.maruhxn.todomon.global.error.exception.BadRequestException;
+import com.maruhxn.todomon.global.error.exception.ForbiddenException;
 import com.maruhxn.todomon.global.error.exception.NotFoundException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -23,18 +24,16 @@ public class FollowService {
     private final FollowRepository followRepository;
 
     // 팔로우 요청을 보낸다.
-    public void sendFollowRequest(Long followerId, Long followeeId) {
+    public void sendFollowRequest(Member follower, Long followeeId) {
         // 자기 자신은 팔로우 안됨
-        if (followerId == followeeId) throw new BadRequestException(ErrorCode.BAD_REQUEST);
+        if (follower.getId() == followeeId) throw new BadRequestException(ErrorCode.BAD_REQUEST);
 
         // 팔로우 정보가 이미 존재하는지 확인
-        followRepository.findByFollower_IdAndFollowee_Id(followerId, followeeId)
+        followRepository.findByFollower_IdAndFollowee_Id(follower.getId(), followeeId)
                 .ifPresent(f -> {
                     throw new BadRequestException(ErrorCode.BAD_REQUEST);
                 });
 
-        Member follower = memberRepository.findById(followerId)
-                .orElseThrow(() -> new NotFoundException(ErrorCode.NOT_FOUND_MEMBER, "팔로워 정보가 존재하지 않습니다."));
         Member followee = memberRepository.findById(followeeId)
                 .orElseThrow(() -> new NotFoundException(ErrorCode.NOT_FOUND_MEMBER, "팔로위 정보가 존재하지 않습니다."));
 
@@ -57,14 +56,19 @@ public class FollowService {
     }
 
     // 팔로우를 취소한다.
-    public void unfollow(Long followerId, Long followeeId) {
-        memberRepository.findById(followerId)
-                .orElseThrow(() -> new NotFoundException(ErrorCode.NOT_FOUND_MEMBER, "팔로워 정보가 존재하지 않습니다."));
+    public void unfollow(Member follower, Long followeeId) {
         memberRepository.findById(followeeId)
                 .orElseThrow(() -> new NotFoundException(ErrorCode.NOT_FOUND_MEMBER, "팔로위 정보가 존재하지 않습니다."));
 
-        Follow findFollow = followRepository.findByFollower_IdAndFollowee_Id(followerId, followeeId)
+        Follow findFollow = followRepository.findByFollower_IdAndFollowee_Id(follower.getId(), followeeId)
                 .orElseThrow(() -> new NotFoundException(ErrorCode.NOT_FOUND_FOLLOW));
         followRepository.delete(findFollow);
+    }
+
+    public void checkIsFollow(Long follwerId, Long followeeId) {
+        Follow findFollow = followRepository.findByFollower_IdAndFollowee_Id(follwerId, followeeId)
+                .orElseThrow(() -> new NotFoundException(ErrorCode.NOT_FOUND_FOLLOW));
+
+        if (findFollow.getStatus() != ACCEPTED) throw new ForbiddenException(ErrorCode.NOT_ACCEPTED_FOLLOW);
     }
 }

--- a/src/main/java/com/maruhxn/todomon/domain/social/application/FollowService.java
+++ b/src/main/java/com/maruhxn/todomon/domain/social/application/FollowService.java
@@ -1,0 +1,70 @@
+package com.maruhxn.todomon.domain.social.application;
+
+import com.maruhxn.todomon.domain.member.dao.MemberRepository;
+import com.maruhxn.todomon.domain.member.domain.Member;
+import com.maruhxn.todomon.domain.social.dao.FollowRepository;
+import com.maruhxn.todomon.domain.social.domain.Follow;
+import com.maruhxn.todomon.global.error.ErrorCode;
+import com.maruhxn.todomon.global.error.exception.BadRequestException;
+import com.maruhxn.todomon.global.error.exception.NotFoundException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import static com.maruhxn.todomon.domain.social.domain.FollowRequestStatus.ACCEPTED;
+import static com.maruhxn.todomon.domain.social.domain.FollowRequestStatus.REJECTED;
+
+@Service
+@Transactional
+@RequiredArgsConstructor
+public class FollowService {
+
+    private final MemberRepository memberRepository;
+    private final FollowRepository followRepository;
+
+    // 팔로우 요청을 보낸다.
+    public void sendFollowRequest(Long followerId, Long followeeId) {
+        // 자기 자신은 팔로우 안됨
+        if (followerId == followeeId) throw new BadRequestException(ErrorCode.BAD_REQUEST);
+
+        // 팔로우 정보가 이미 존재하는지 확인
+        followRepository.findByFollower_IdAndFollowee_Id(followerId, followeeId)
+                .ifPresent(f -> {
+                    throw new BadRequestException(ErrorCode.BAD_REQUEST);
+                });
+
+        Member follower = memberRepository.findById(followerId)
+                .orElseThrow(() -> new NotFoundException(ErrorCode.NOT_FOUND_MEMBER, "팔로워 정보가 존재하지 않습니다."));
+        Member followee = memberRepository.findById(followeeId)
+                .orElseThrow(() -> new NotFoundException(ErrorCode.NOT_FOUND_MEMBER, "팔로위 정보가 존재하지 않습니다."));
+
+        Follow follow = Follow.builder()
+                .follower(follower)
+                .followee(followee)
+                .build();
+
+        follower.getFollowings().add(follow);
+        followRepository.save(follow);
+    }
+
+    // 팔로우 요청에 대해 응답한다.
+    public void respondToFollowRequest(Long followId, boolean isAccepted) {
+        Follow follow = followRepository.findById(followId)
+                .orElseThrow(() -> new NotFoundException(ErrorCode.NOT_FOUND_FOLLOW));
+
+        follow.updateStatus(isAccepted ? ACCEPTED : REJECTED);
+        followRepository.save(follow);
+    }
+
+    // 팔로우를 취소한다.
+    public void unfollow(Long followerId, Long followeeId) {
+        memberRepository.findById(followerId)
+                .orElseThrow(() -> new NotFoundException(ErrorCode.NOT_FOUND_MEMBER, "팔로워 정보가 존재하지 않습니다."));
+        memberRepository.findById(followeeId)
+                .orElseThrow(() -> new NotFoundException(ErrorCode.NOT_FOUND_MEMBER, "팔로위 정보가 존재하지 않습니다."));
+
+        Follow findFollow = followRepository.findByFollower_IdAndFollowee_Id(followerId, followeeId)
+                .orElseThrow(() -> new NotFoundException(ErrorCode.NOT_FOUND_FOLLOW));
+        followRepository.delete(findFollow);
+    }
+}

--- a/src/main/java/com/maruhxn/todomon/domain/social/application/OverallRankQueryService.java
+++ b/src/main/java/com/maruhxn/todomon/domain/social/application/OverallRankQueryService.java
@@ -1,0 +1,37 @@
+package com.maruhxn.todomon.domain.social.application;
+
+import com.maruhxn.todomon.domain.member.dao.MemberQueryRepository;
+import com.maruhxn.todomon.domain.pet.dao.CollectedPetQueryRepository;
+import com.maruhxn.todomon.domain.social.dto.response.CollectedPetRankItem;
+import com.maruhxn.todomon.domain.social.dto.response.DiligenceRankItem;
+import com.maruhxn.todomon.domain.social.dto.response.TodoAchievementRankItem;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Service
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+public class OverallRankQueryService {
+
+    private final MemberQueryRepository memberQueryRepository;
+    private final CollectedPetQueryRepository collectedPetQueryRepository;
+
+    public List<DiligenceRankItem> getTop10MembersByDiligenceLevelAndGauge() {
+        return memberQueryRepository.findTop10MembersByDiligenceLevelAndGauge();
+    }
+
+    public List<CollectedPetRankItem> getTop10MembersByCollectedPetCnt() {
+        return collectedPetQueryRepository.findTop10MembersByCollectedPetCnt();
+    }
+
+    public List<TodoAchievementRankItem> getRankingOfDailyAchievement() {
+        return memberQueryRepository.findTop10MembersByYesterdayAchievement();
+    }
+
+    public List<TodoAchievementRankItem> getRankingOfWeeklyAchievement() {
+        return memberQueryRepository.findTop10MembersByWeeklyAchievement();
+    }
+}

--- a/src/main/java/com/maruhxn/todomon/domain/social/application/SocialRankQueryService.java
+++ b/src/main/java/com/maruhxn/todomon/domain/social/application/SocialRankQueryService.java
@@ -1,0 +1,37 @@
+package com.maruhxn.todomon.domain.social.application;
+
+import com.maruhxn.todomon.domain.member.domain.Member;
+import com.maruhxn.todomon.domain.social.dao.SocialQueryRepository;
+import com.maruhxn.todomon.domain.social.dto.response.CollectedPetRankItem;
+import com.maruhxn.todomon.domain.social.dto.response.DiligenceRankItem;
+import com.maruhxn.todomon.domain.social.dto.response.TodoAchievementRankItem;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Service
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+public class SocialRankQueryService {
+
+    private final SocialQueryRepository socialQueryRepository;
+
+    public List<DiligenceRankItem> getSocialRankingOfDiligence(Member member) {
+        return socialQueryRepository.findTop10MembersByDiligenceLevelAndGauge(member);
+    }
+
+    public List<CollectedPetRankItem> getSocialRankingOfCollection(Member member) {
+        return socialQueryRepository.findTop10MembersByCollectedPetCnt(member);
+    }
+
+    public List<TodoAchievementRankItem> getSocialRankingOfDailyAchievement(Member member) {
+        return socialQueryRepository.findTop10MembersByYesterdayAchievement(member);
+    }
+
+    public List<TodoAchievementRankItem> getSocialRankingOfWeeklyAchievement(Member member) {
+        return socialQueryRepository.findTop10MembersByWeeklyAchievement(member);
+    }
+
+}

--- a/src/main/java/com/maruhxn/todomon/domain/social/application/StarService.java
+++ b/src/main/java/com/maruhxn/todomon/domain/social/application/StarService.java
@@ -1,0 +1,60 @@
+package com.maruhxn.todomon.domain.social.application;
+
+import com.maruhxn.todomon.domain.member.dao.MemberRepository;
+import com.maruhxn.todomon.domain.member.domain.Member;
+import com.maruhxn.todomon.domain.social.dao.StarTransactionRepository;
+import com.maruhxn.todomon.domain.social.domain.StarTransaction;
+import com.maruhxn.todomon.global.error.ErrorCode;
+import com.maruhxn.todomon.global.error.exception.BadRequestException;
+import com.maruhxn.todomon.global.error.exception.NotFoundException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+import static com.maruhxn.todomon.domain.social.domain.StarTransactionStatus.RECEIVED;
+import static com.maruhxn.todomon.domain.social.domain.StarTransactionStatus.SENT;
+
+@Service
+@Transactional
+@RequiredArgsConstructor
+public class StarService {
+
+    private final MemberRepository memberRepository;
+    private final StarTransactionRepository starTransactionRepository;
+    private final FollowService followService;
+
+    public void sendStar(Member sender, Long receiverId) {
+        // 수신자 존재하는지 확인
+        Member receiver = memberRepository.findById(receiverId)
+                .orElseThrow(() -> new NotFoundException(ErrorCode.NOT_FOUND_MEMBER, "수신자 정보가 존재하지 않습니다."));
+
+        // 서로 팔로우하고 있는지 확인 -> 맞팔로우하지 않은 상대에게는 star를 보낼 수 없음
+        followService.checkIsFollow(sender.getId(), receiverId);
+
+        StarTransaction transaction = StarTransaction.createTransaction(sender, receiver);
+
+        starTransactionRepository.save(transaction);
+    }
+
+    public void receiveOneStar(Member receiver, Long transactionId) {
+        StarTransaction transaction = starTransactionRepository.findById(transactionId)
+                .orElseThrow(() -> new NotFoundException(ErrorCode.NOT_FOUND_STAR_TRANSACTION));
+
+        if (transaction.getStatus() == RECEIVED) throw new BadRequestException(ErrorCode.ALREADY_RECEIVED);
+
+        receiver.addStar(1);
+        transaction.updateStatus(RECEIVED);
+    }
+
+    public void receiveAllStars(Member receiver) {
+        List<StarTransaction> transactions = starTransactionRepository.findAllByReceiver_IdAndStatus(receiver.getId(), SENT);
+
+        transactions.forEach(tx -> {
+            tx.updateStatus(RECEIVED);
+        });
+
+        receiver.addStar(transactions.size());
+    }
+}

--- a/src/main/java/com/maruhxn/todomon/domain/social/dao/FollowRepository.java
+++ b/src/main/java/com/maruhxn/todomon/domain/social/dao/FollowRepository.java
@@ -1,0 +1,18 @@
+package com.maruhxn.todomon.domain.social.dao;
+
+import com.maruhxn.todomon.domain.member.domain.Member;
+import com.maruhxn.todomon.domain.social.domain.Follow;
+import com.maruhxn.todomon.domain.social.domain.FollowRequestStatus;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+import java.util.Optional;
+
+public interface FollowRepository extends JpaRepository<Follow, Long> {
+    Optional<Follow> findByFollower_IdAndFollowee_Id(Long followerId, Long followeeId);
+
+    List<Follow> findByFollowerAndStatusOrderByCreatedAtDesc(Member follower, FollowRequestStatus followRequestStatus); // follower가 전달값과 일치하는 Follow 모두 찾기
+
+    List<Follow> findByFolloweeAndStatusOrderByCreatedAtDesc(Member followee, FollowRequestStatus followRequestStatus); // followee가 전달값과 일치하는 Follow 모두 찾기
+
+}

--- a/src/main/java/com/maruhxn/todomon/domain/social/dao/SocialQueryRepository.java
+++ b/src/main/java/com/maruhxn/todomon/domain/social/dao/SocialQueryRepository.java
@@ -1,0 +1,145 @@
+package com.maruhxn.todomon.domain.social.dao;
+
+import com.maruhxn.todomon.domain.member.domain.Member;
+import com.maruhxn.todomon.domain.social.domain.FollowRequestStatus;
+import com.maruhxn.todomon.domain.social.dto.response.CollectedPetRankItem;
+import com.maruhxn.todomon.domain.social.dto.response.DiligenceRankItem;
+import com.maruhxn.todomon.domain.social.dto.response.TodoAchievementRankItem;
+import com.querydsl.core.types.Projections;
+import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+import java.time.DayOfWeek;
+import java.time.LocalDate;
+import java.time.temporal.TemporalAdjusters;
+import java.util.List;
+
+import static com.maruhxn.todomon.domain.member.domain.QDiligence.diligence;
+import static com.maruhxn.todomon.domain.member.domain.QMember.member;
+import static com.maruhxn.todomon.domain.pet.domain.QCollectedPet.collectedPet;
+import static com.maruhxn.todomon.domain.social.domain.QFollow.follow;
+import static com.maruhxn.todomon.domain.todo.domain.QTodoAchievementHistory.todoAchievementHistory;
+
+@Repository
+@RequiredArgsConstructor
+public class SocialQueryRepository {
+
+    private final JPAQueryFactory query;
+
+    public List<DiligenceRankItem> findTop10MembersByDiligenceLevelAndGauge(Member currentMember) {
+        return query
+                .select(
+                        Projections.fields(DiligenceRankItem.class,
+                                member.id,
+                                member.username,
+                                member.profileImageUrl,
+                                diligence.level
+                        )
+                )
+                .from(member)
+                .leftJoin(follow).on(follow.followee.id.eq(member.id).and(isAccepted()))
+                .join(member.diligence, diligence)
+                .where(
+                        followerIsCurrentMember(currentMember.getId())
+                                .or(isCurrentMember(currentMember.getId()))
+                )
+                .orderBy(diligence.level.desc(), diligence.gauge.desc(), member.createdAt.asc())
+                .limit(10)
+                .fetch();
+    }
+
+    public List<CollectedPetRankItem> findTop10MembersByCollectedPetCnt(Member currentMember) {
+        return query.select(
+                        Projections.fields(CollectedPetRankItem.class,
+                                member.id,
+                                member.username,
+                                member.profileImageUrl,
+                                collectedPet.id.count().intValue().as("petCnt"),
+                                collectedPet.createdAt.max().as("lastCollectedAt")
+                        )
+                )
+                .from(member)
+                .leftJoin(follow).on(follow.followee.id.eq(member.id).and(isAccepted()))
+                .leftJoin(member.collectedPets, collectedPet)
+                .where(
+                        followerIsCurrentMember(currentMember.getId())
+                                .or(isCurrentMember(currentMember.getId()))
+                )
+                .groupBy(member.id, member.username, member.profileImageUrl)
+                .orderBy(collectedPet.id.count().desc(), collectedPet.createdAt.max().desc(), member.createdAt.asc())
+                .limit(10)
+                .fetch();
+    }
+
+    public List<TodoAchievementRankItem> findTop10MembersByYesterdayAchievement(Member currentMember) {
+        LocalDate yesterday = LocalDate.now().minusDays(1);
+
+        return query.select(
+                        Projections.fields(TodoAchievementRankItem.class,
+                                member.id,
+                                member.username,
+                                member.profileImageUrl,
+                                todoAchievementHistory.cnt
+                        )
+                )
+                .from(member)
+                .leftJoin(follow).on(follow.followee.id.eq(member.id).and(isAccepted()))
+                .join(member.todoAchievementHistories, todoAchievementHistory)
+                .where(
+                        (
+                                followerIsCurrentMember(currentMember.getId())
+                                        .or(isCurrentMember(currentMember.getId()))
+                        )
+                                .and(todoAchievementHistory.date.eq(yesterday))
+                )
+                .groupBy(member.id)
+                .orderBy(todoAchievementHistory.cnt.sum().desc(), todoAchievementHistory.createdAt.max().asc(), member.createdAt.asc())
+                .limit(10)
+                .fetch();
+    }
+
+    private static BooleanExpression isAccepted() {
+        return follow.status.eq(FollowRequestStatus.ACCEPTED);
+    }
+
+    public List<TodoAchievementRankItem> findTop10MembersByWeeklyAchievement(Member currentMember) {
+        LocalDate startOfCurrentWeek = LocalDate.now().with(TemporalAdjusters.previousOrSame(DayOfWeek.MONDAY));
+        LocalDate startOfLastWeek = startOfCurrentWeek.minusWeeks(1);
+        LocalDate endOfLastWeek = startOfCurrentWeek.minusDays(1);
+
+        return query.select(
+                        Projections.fields(TodoAchievementRankItem.class,
+                                member.id,
+                                member.username,
+                                member.profileImageUrl,
+                                todoAchievementHistory.cnt
+                        )
+                )
+                .from(member)
+                .leftJoin(follow).on(follow.followee.id.eq(member.id).and(isAccepted()))
+                .join(member.todoAchievementHistories, todoAchievementHistory)
+                .where(
+                        (
+                                followerIsCurrentMember(currentMember.getId())
+                                        .or(isCurrentMember(currentMember.getId()))
+                        )
+                                .and(todoAchievementHistory.date.between(startOfLastWeek, endOfLastWeek))
+                )
+                .groupBy(member.id)
+                .orderBy(todoAchievementHistory.cnt.sum().desc(), todoAchievementHistory.createdAt.max().asc(), member.createdAt.asc())
+                .limit(10)
+                .fetch();
+    }
+
+
+    private BooleanExpression followerIsCurrentMember(Long currentMemberId) {
+        return currentMemberId != null ? follow.follower.id.eq(currentMemberId) : null;
+    }
+
+    private BooleanExpression isCurrentMember(Long currentMemberId) {
+        return currentMemberId != null ? member.id.eq(currentMemberId) : null;
+    }
+}
+

--- a/src/main/java/com/maruhxn/todomon/domain/social/dao/StarTransactionRepository.java
+++ b/src/main/java/com/maruhxn/todomon/domain/social/dao/StarTransactionRepository.java
@@ -1,0 +1,11 @@
+package com.maruhxn.todomon.domain.social.dao;
+
+import com.maruhxn.todomon.domain.social.domain.StarTransaction;
+import com.maruhxn.todomon.domain.social.domain.StarTransactionStatus;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface StarTransactionRepository extends JpaRepository<StarTransaction, Long> {
+    List<StarTransaction> findAllByReceiver_IdAndStatus(Long receiverId, StarTransactionStatus status);
+}

--- a/src/main/java/com/maruhxn/todomon/domain/social/domain/Follow.java
+++ b/src/main/java/com/maruhxn/todomon/domain/social/domain/Follow.java
@@ -1,0 +1,37 @@
+package com.maruhxn.todomon.domain.social.domain;
+
+import com.maruhxn.todomon.domain.member.domain.Member;
+import com.maruhxn.todomon.global.common.BaseEntity;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Follow extends BaseEntity {
+
+    @Enumerated(EnumType.STRING)
+    private FollowRequestStatus status;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "follower_id", nullable = false, referencedColumnName = "id")
+    private Member follower;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "followee_id", nullable = false, referencedColumnName = "id")
+    private Member followee;
+
+    @Builder
+    public Follow(Member follower, Member followee) {
+        this.status = FollowRequestStatus.PENDING;
+        this.follower = follower;
+        this.followee = followee;
+    }
+
+    public void updateStatus(FollowRequestStatus status) {
+        this.status = status;
+    }
+}

--- a/src/main/java/com/maruhxn/todomon/domain/social/domain/FollowRequestStatus.java
+++ b/src/main/java/com/maruhxn/todomon/domain/social/domain/FollowRequestStatus.java
@@ -1,0 +1,5 @@
+package com.maruhxn.todomon.domain.social.domain;
+
+public enum FollowRequestStatus {
+    PENDING, ACCEPTED, REJECTED
+}

--- a/src/main/java/com/maruhxn/todomon/domain/social/domain/StarTransaction.java
+++ b/src/main/java/com/maruhxn/todomon/domain/social/domain/StarTransaction.java
@@ -1,0 +1,39 @@
+package com.maruhxn.todomon.domain.social.domain;
+
+import com.maruhxn.todomon.domain.member.domain.Member;
+import com.maruhxn.todomon.global.common.BaseEntity;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class StarTransaction extends BaseEntity {
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "sender_id", nullable = false, referencedColumnName = "id")
+    private Member sender;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "receiver_id", nullable = false, referencedColumnName = "id")
+    private Member receiver;
+
+    @Enumerated(EnumType.STRING)
+    private StarTransactionStatus status;
+
+    private StarTransaction(Member sender, Member receiver) {
+        this.sender = sender;
+        this.receiver = receiver;
+        this.status = StarTransactionStatus.SENT;
+    }
+
+    public static StarTransaction createTransaction(Member sender, Member receiver) {
+        return new StarTransaction(sender, receiver);
+    }
+
+    public void updateStatus(StarTransactionStatus status) {
+        this.status = status;
+    }
+}

--- a/src/main/java/com/maruhxn/todomon/domain/social/domain/StarTransactionStatus.java
+++ b/src/main/java/com/maruhxn/todomon/domain/social/domain/StarTransactionStatus.java
@@ -1,0 +1,5 @@
+package com.maruhxn.todomon.domain.social.domain;
+
+public enum StarTransactionStatus {
+    SENT, RECEIVED
+}

--- a/src/main/java/com/maruhxn/todomon/domain/social/dto/response/CollectedPetRankItem.java
+++ b/src/main/java/com/maruhxn/todomon/domain/social/dto/response/CollectedPetRankItem.java
@@ -1,0 +1,28 @@
+package com.maruhxn.todomon.domain.social.dto.response;
+
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Getter
+@NoArgsConstructor
+public class CollectedPetRankItem {
+
+    private Long id;
+    private String username;
+    private String profileImageUrl;
+    private int petCnt;
+    private LocalDateTime lastCollectedAt;
+
+    @Builder
+    public CollectedPetRankItem(Long id, String username, String profileImageUrl, int petCnt, LocalDateTime lastCollectedAt) {
+        this.id = id;
+        this.username = username;
+        this.profileImageUrl = profileImageUrl;
+        this.petCnt = petCnt;
+        this.lastCollectedAt = lastCollectedAt;
+    }
+}

--- a/src/main/java/com/maruhxn/todomon/domain/social/dto/response/DiligenceRankItem.java
+++ b/src/main/java/com/maruhxn/todomon/domain/social/dto/response/DiligenceRankItem.java
@@ -1,0 +1,24 @@
+package com.maruhxn.todomon.domain.social.dto.response;
+
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class DiligenceRankItem {
+
+    // rank는 클라이언트에서 받아온 순서대로 처리
+    private Long id;
+    private String username;
+    private String profileImageUrl;
+    private int level;
+
+    @Builder
+    public DiligenceRankItem(Long id, String username, String profileImageUrl, int level) {
+        this.id = id;
+        this.username = username;
+        this.profileImageUrl = profileImageUrl;
+        this.level = level;
+    }
+}

--- a/src/main/java/com/maruhxn/todomon/domain/social/dto/response/FollowItem.java
+++ b/src/main/java/com/maruhxn/todomon/domain/social/dto/response/FollowItem.java
@@ -1,0 +1,31 @@
+package com.maruhxn.todomon.domain.social.dto.response;
+
+import com.maruhxn.todomon.domain.member.domain.Member;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class FollowItem {
+
+    private Long id;
+    private String username;
+    private String profileImageUrl;
+
+    @Builder
+    public FollowItem(Long id, String username, String profileImageUrl) {
+        this.id = id;
+        this.username = username;
+        this.profileImageUrl = profileImageUrl;
+    }
+
+    public static FollowItem of(Member member) {
+        return FollowItem.builder()
+                .id(member.getId())
+                .username(member.getUsername())
+                .profileImageUrl(member.getProfileImageUrl())
+                .build();
+    }
+}

--- a/src/main/java/com/maruhxn/todomon/domain/social/dto/response/TodoAchievementRankItem.java
+++ b/src/main/java/com/maruhxn/todomon/domain/social/dto/response/TodoAchievementRankItem.java
@@ -1,0 +1,23 @@
+package com.maruhxn.todomon.domain.social.dto.response;
+
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class TodoAchievementRankItem {
+
+    private Long id;
+    private String username;
+    private String profileImageUrl;
+    private long cnt;
+
+    @Builder
+    public TodoAchievementRankItem(Long id, String username, String profileImageUrl, long cnt) {
+        this.id = id;
+        this.username = username;
+        this.profileImageUrl = profileImageUrl;
+        this.cnt = cnt;
+    }
+}

--- a/src/main/java/com/maruhxn/todomon/domain/todo/application/TodoService.java
+++ b/src/main/java/com/maruhxn/todomon/domain/todo/application/TodoService.java
@@ -239,6 +239,7 @@ public class TodoService {
     }
 
     private void withdrawReward(Member member, int leverage) {
+        member.addDailyAchievementCnt(-1);
         member.getDiligence().decreaseGauge(GAUGE_INCREASE_RATE * leverage);
         member.subtractScheduledReward((long) (REWARD_UNIT * leverage * REWARD_LEVERAGE_RATE));
     }

--- a/src/main/java/com/maruhxn/todomon/domain/todo/application/TodoService.java
+++ b/src/main/java/com/maruhxn/todomon/domain/todo/application/TodoService.java
@@ -245,6 +245,8 @@ public class TodoService {
 
     // 단일 일정에 대한 보상 로직
     private void reward(Member member, int leverage) {
+        // 일간 달성 수 1 증가
+        member.addDailyAchievementCnt(1);
         // 유저 일관성 게이지 업데이트
         member.getDiligence().increaseGauge(GAUGE_INCREASE_RATE * leverage);
         // 보상 지급

--- a/src/main/java/com/maruhxn/todomon/domain/todo/dao/TodoAchievementHistoryRepository.java
+++ b/src/main/java/com/maruhxn/todomon/domain/todo/dao/TodoAchievementHistoryRepository.java
@@ -1,0 +1,7 @@
+package com.maruhxn.todomon.domain.todo.dao;
+
+import com.maruhxn.todomon.domain.todo.domain.TodoAchievementHistory;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface TodoAchievementHistoryRepository extends JpaRepository<TodoAchievementHistory, Long> {
+}

--- a/src/main/java/com/maruhxn/todomon/domain/todo/domain/TodoAchievementHistory.java
+++ b/src/main/java/com/maruhxn/todomon/domain/todo/domain/TodoAchievementHistory.java
@@ -1,0 +1,35 @@
+package com.maruhxn.todomon.domain.todo.domain;
+
+import com.maruhxn.todomon.domain.member.domain.Member;
+import com.maruhxn.todomon.global.common.BaseEntity;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDate;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class TodoAchievementHistory extends BaseEntity {
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "member_id", referencedColumnName = "id")
+    private Member member;
+
+    private Long cnt;
+
+    private LocalDate date;
+
+    @Builder
+    public TodoAchievementHistory(Member member, Long cnt, LocalDate date) {
+        this.member = member;
+        this.cnt = cnt;
+        this.date = date;
+    }
+}

--- a/src/main/java/com/maruhxn/todomon/global/config/JpaConfig.java
+++ b/src/main/java/com/maruhxn/todomon/global/config/JpaConfig.java
@@ -1,9 +1,17 @@
 package com.maruhxn.todomon.global.config;
 
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import jakarta.persistence.EntityManager;
+import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
 @Configuration
 @EnableJpaAuditing
 public class JpaConfig {
+
+    @Bean
+    JPAQueryFactory jpaQueryFactory(EntityManager em) {
+        return new JPAQueryFactory((em));
+    }
 }

--- a/src/main/java/com/maruhxn/todomon/global/config/ScheduleConfig.java
+++ b/src/main/java/com/maruhxn/todomon/global/config/ScheduleConfig.java
@@ -1,0 +1,9 @@
+package com.maruhxn.todomon.global.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.annotation.EnableScheduling;
+
+@Configuration
+@EnableScheduling
+public class ScheduleConfig {
+}

--- a/src/main/java/com/maruhxn/todomon/global/error/ErrorCode.java
+++ b/src/main/java/com/maruhxn/todomon/global/error/ErrorCode.java
@@ -29,6 +29,7 @@ public enum ErrorCode {
     NOT_FOUND_REFRESH_TOKEN("Refresh Token 정보가 존재하지 않습니다."),
     NOT_FOUND_TODO("할 일 정보가 존재하지 않습니다."),
     NOT_FOUND_PET("펫 정보가 존재하지 않습니다."),
+    NOT_FOUND_FOLLOW("팔로우 정보가 존재하지 않습니다."),
 
     /* UNPROCESSABLE CONTENT 422 */
     EXISTING_RESOURCE("이미 존재하는 리소스입니다."),

--- a/src/main/java/com/maruhxn/todomon/global/error/ErrorCode.java
+++ b/src/main/java/com/maruhxn/todomon/global/error/ErrorCode.java
@@ -13,6 +13,7 @@ public enum ErrorCode {
     EMPTY_REFRESH_TOKEN("Refresh Token이 비어있습니다."),
     OVER_FOOD_CNT("소지한 먹이 수보다 요청된 먹이 수가 더 많습니다."),
     NO_SPACE_PET_HOUSE("펫 하우스의 공간이 부족합니다."),
+    ALREADY_RECEIVED("이미 STAR를 받았습니다."),
 
 
     /* UNAUTHORIZED 401 */
@@ -22,6 +23,7 @@ public enum ErrorCode {
     /* FORBIDDEN 403 */
     FORBIDDEN("권한이 없습니다."),
     NOT_SUBSCRIPTION("구독하지 않은 이용자입니다. 해당 서비스를 이용하려면 유료 플랜을 구독해주세요."),
+    NOT_ACCEPTED_FOLLOW("팔로우하고 있지 않은 사용자입니다."),
 
     /* NOT FOUND 404 */
     NOT_FOUND_RESOURCE("요청하신 자원이 존재하지 않습니다."),
@@ -30,6 +32,7 @@ public enum ErrorCode {
     NOT_FOUND_TODO("할 일 정보가 존재하지 않습니다."),
     NOT_FOUND_PET("펫 정보가 존재하지 않습니다."),
     NOT_FOUND_FOLLOW("팔로우 정보가 존재하지 않습니다."),
+    NOT_FOUND_STAR_TRANSACTION("STAR 발신 내역이 없습니다."),
 
     /* UNPROCESSABLE CONTENT 422 */
     EXISTING_RESOURCE("이미 존재하는 리소스입니다."),

--- a/src/main/java/com/maruhxn/todomon/global/schedule/ScheduleService.java
+++ b/src/main/java/com/maruhxn/todomon/global/schedule/ScheduleService.java
@@ -1,0 +1,43 @@
+package com.maruhxn.todomon.global.schedule;
+
+import com.maruhxn.todomon.domain.member.dao.MemberRepository;
+import com.maruhxn.todomon.domain.member.domain.Member;
+import com.maruhxn.todomon.domain.todo.dao.TodoAchievementHistoryRepository;
+import com.maruhxn.todomon.domain.todo.domain.TodoAchievementHistory;
+import lombok.RequiredArgsConstructor;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDate;
+import java.util.List;
+
+@Service
+@Transactional
+@RequiredArgsConstructor
+public class ScheduleService {
+
+    private final MemberRepository memberRepository;
+    private final TodoAchievementHistoryRepository todoAchievementHistoryRepository;
+
+    @Scheduled(cron = "0 0 0 * * *") // 매일 00시에 실행
+    @Transactional
+    public void saveDailyAchievementAndReset() {
+        List<Member> members = memberRepository.findAllWithLock();
+
+        LocalDate yesterday = LocalDate.now().minusDays(1);
+
+        for (Member member : members) {
+            TodoAchievementHistory history = TodoAchievementHistory.builder()
+                    .cnt(member.getDailyAchievementCnt())
+                    .date(yesterday)
+                    .member(member)
+                    .build();
+            todoAchievementHistoryRepository.save(history);
+
+            member.resetDailyAchievement();
+        }
+
+        memberRepository.saveAll(members);
+    }
+}

--- a/src/test/java/com/maruhxn/todomon/domain/pet/application/PetServiceTest.java
+++ b/src/test/java/com/maruhxn/todomon/domain/pet/application/PetServiceTest.java
@@ -200,12 +200,8 @@ class PetServiceTest extends IntegrationTestSupport {
         member.addFood(10);
         petRepository.save(pet);
 
-        CollectedPet collectedPet = CollectedPet.builder()
-                .rarity(pet.getRarity())
-                .evolutionCnt(pet.getEvolutionCnt())
-                .petType(pet.getPetType())
-                .build();
-        collectedPet.setMember(member);
+        CollectedPet collectedPet = CollectedPet.of(pet);
+        member.addCollection(collectedPet);
         collectedPetRepository.save(collectedPet);
 
         FeedReq req = new FeedReq(10);

--- a/src/test/java/com/maruhxn/todomon/domain/social/application/FollowQueryServiceTest.java
+++ b/src/test/java/com/maruhxn/todomon/domain/social/application/FollowQueryServiceTest.java
@@ -1,0 +1,157 @@
+package com.maruhxn.todomon.domain.social.application;
+
+import com.maruhxn.todomon.domain.member.dao.MemberRepository;
+import com.maruhxn.todomon.domain.member.domain.Member;
+import com.maruhxn.todomon.domain.social.dao.FollowRepository;
+import com.maruhxn.todomon.domain.social.domain.Follow;
+import com.maruhxn.todomon.domain.social.dto.response.FollowItem;
+import com.maruhxn.todomon.global.auth.model.Role;
+import com.maruhxn.todomon.global.auth.model.provider.OAuth2Provider;
+import com.maruhxn.todomon.util.IntegrationTestSupport;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import java.util.List;
+
+import static com.maruhxn.todomon.domain.social.domain.FollowRequestStatus.ACCEPTED;
+import static com.maruhxn.todomon.domain.social.domain.FollowRequestStatus.REJECTED;
+import static org.assertj.core.api.Assertions.assertThat;
+
+@DisplayName("[Service] - FollowQueryService")
+class FollowQueryServiceTest extends IntegrationTestSupport {
+
+    @Autowired
+    FollowQueryService followQueryService;
+
+    @Autowired
+    MemberRepository memberRepository;
+
+    @Autowired
+    FollowRepository followRepository;
+
+    @Test
+    @DisplayName("유저의 팔로잉 리스트를 조회한다")
+    void followingList() {
+        // given
+        Member tester1 = createMember("tester1");
+        Member tester2 = createMember("tester2");
+        Member tester3 = createMember("tester3");
+        Member tester4 = createMember("tester4");
+
+        Follow follow1 = Follow.builder()
+                .follower(tester1)
+                .followee(tester2)
+                .build();
+        Follow follow2 = Follow.builder()
+                .follower(tester1)
+                .followee(tester3)
+                .build();
+
+        Follow follow3 = Follow.builder()
+                .follower(tester1)
+                .followee(tester4)
+                .build();
+
+        follow1.updateStatus(ACCEPTED);
+        follow2.updateStatus(REJECTED);
+        follow3.updateStatus(ACCEPTED);
+        followRepository.saveAll(List.of(follow1, follow2, follow3));
+        // when
+        List<FollowItem> followingList = followQueryService.followingList(tester1.getId());
+
+        // then
+        assertThat(followingList)
+                .hasSize(2)
+                .first()
+                .extracting("id", "username", "profileImageUrl")
+                .containsExactly(tester4.getId(), tester4.getUsername(), tester4.getProfileImageUrl());
+    }
+
+    @Test
+    @DisplayName("유저의 팔로워 리스트를 조회한다")
+    void followerList() {
+        // given
+        Member tester1 = createMember("tester1");
+        Member tester2 = createMember("tester2");
+        Member tester3 = createMember("tester3");
+        Member tester4 = createMember("tester4");
+
+        Follow follow1 = Follow.builder()
+                .follower(tester2)
+                .followee(tester1)
+                .build();
+        Follow follow2 = Follow.builder()
+                .follower(tester3)
+                .followee(tester1)
+                .build();
+
+        Follow follow3 = Follow.builder()
+                .follower(tester4)
+                .followee(tester1)
+                .build();
+
+        follow1.updateStatus(ACCEPTED);
+        follow2.updateStatus(REJECTED);
+        follow3.updateStatus(ACCEPTED);
+        followRepository.saveAll(List.of(follow1, follow2, follow3));
+        // when
+        List<FollowItem> followerList = followQueryService.followerList(tester1.getId());
+
+        // then
+        assertThat(followerList)
+                .hasSize(2)
+                .first()
+                .extracting("id", "username", "profileImageUrl")
+                .containsExactly(tester4.getId(), tester4.getUsername(), tester4.getProfileImageUrl());
+    }
+
+    @Test
+    @DisplayName("유저의 아직 수락하지 않은 팔로우 요청들을 조회한다")
+    void getPendingFollowRequests() {
+        // given
+        Member tester1 = createMember("tester1");
+        Member tester2 = createMember("tester2");
+        Member tester3 = createMember("tester3");
+        Member tester4 = createMember("tester4");
+
+        Follow follow1 = Follow.builder()
+                .follower(tester2)
+                .followee(tester1)
+                .build();
+        Follow follow2 = Follow.builder()
+                .follower(tester3)
+                .followee(tester1)
+                .build();
+
+        Follow follow3 = Follow.builder()
+                .follower(tester4)
+                .followee(tester1)
+                .build();
+
+        follow1.updateStatus(ACCEPTED);
+        followRepository.saveAll(List.of(follow1, follow2, follow3));
+        // when
+        List<FollowItem> pendingList = followQueryService.getPendingFollowRequests(tester1);
+
+        // then
+        assertThat(pendingList)
+                .hasSize(2)
+                .first()
+                .extracting("id", "username", "profileImageUrl")
+                .containsExactly(tester4.getId(), tester4.getUsername(), tester4.getProfileImageUrl());
+    }
+
+    private Member createMember(String username) {
+        Member member = Member.builder()
+                .username(username)
+                .email(username + "@test.com")
+                .provider(OAuth2Provider.GOOGLE)
+                .providerId("google_" + username)
+                .role(Role.ROLE_USER)
+                .profileImageUrl("profileImageUrl")
+                .build();
+        member.initDiligence();
+        return memberRepository.save(member);
+    }
+}

--- a/src/test/java/com/maruhxn/todomon/domain/social/application/FollowServiceTest.java
+++ b/src/test/java/com/maruhxn/todomon/domain/social/application/FollowServiceTest.java
@@ -34,7 +34,7 @@ class FollowServiceTest extends IntegrationTestSupport {
         Member tester2 = createMember("tester2");
 
         // when
-        followService.sendFollowRequest(tester1.getId(), tester2.getId());
+        followService.sendFollowRequest(tester1, tester2.getId());
 
         // then
         assertThat(followRepository.findAll())
@@ -104,7 +104,7 @@ class FollowServiceTest extends IntegrationTestSupport {
         followRepository.save(follow);
 
         // when
-        followService.unfollow(tester1.getId(), tester2.getId());
+        followService.unfollow(tester1, tester2.getId());
 
         // then
         assertThat(followRepository.findById(follow.getId())).isEmpty();

--- a/src/test/java/com/maruhxn/todomon/domain/social/application/FollowServiceTest.java
+++ b/src/test/java/com/maruhxn/todomon/domain/social/application/FollowServiceTest.java
@@ -1,0 +1,126 @@
+package com.maruhxn.todomon.domain.social.application;
+
+import com.maruhxn.todomon.domain.member.dao.MemberRepository;
+import com.maruhxn.todomon.domain.member.domain.Member;
+import com.maruhxn.todomon.domain.social.dao.FollowRepository;
+import com.maruhxn.todomon.domain.social.domain.Follow;
+import com.maruhxn.todomon.global.auth.model.Role;
+import com.maruhxn.todomon.global.auth.model.provider.OAuth2Provider;
+import com.maruhxn.todomon.util.IntegrationTestSupport;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import static com.maruhxn.todomon.domain.social.domain.FollowRequestStatus.*;
+import static org.assertj.core.api.Assertions.assertThat;
+
+@DisplayName("[Service] - FollowService")
+class FollowServiceTest extends IntegrationTestSupport {
+
+    @Autowired
+    FollowService followService;
+
+    @Autowired
+    MemberRepository memberRepository;
+
+    @Autowired
+    FollowRepository followRepository;
+
+    @Test
+    @DisplayName("팔로우 요청을 보낸다")
+    void sendFollowRequest() {
+        // given
+        Member tester1 = createMember("tester1");
+        Member tester2 = createMember("tester2");
+
+        // when
+        followService.sendFollowRequest(tester1.getId(), tester2.getId());
+
+        // then
+        assertThat(followRepository.findAll())
+                .hasSize(1)
+                .first()
+                .extracting("follower", "followee", "status")
+                .containsExactly(tester1, tester2, PENDING);
+    }
+
+    @Test
+    @DisplayName("팔로우 요청을 수락한다")
+    void acceptFollow() {
+        // given
+        Member tester1 = createMember("tester1");
+        Member tester2 = createMember("tester2");
+        Follow follow = Follow.builder()
+                .follower(tester1)
+                .followee(tester2)
+                .build();
+        followRepository.save(follow);
+
+        // when
+        followService.respondToFollowRequest(follow.getId(), true);
+
+        // then
+        assertThat(followRepository.findAll())
+                .hasSize(1)
+                .first()
+                .extracting("follower", "followee", "status")
+                .containsExactly(tester1, tester2, ACCEPTED);
+    }
+
+    @Test
+    @DisplayName("팔로우 요청을 거절한다")
+    void rejectFollow() {
+        // given
+        Member tester1 = createMember("tester1");
+        Member tester2 = createMember("tester2");
+        Follow follow = Follow.builder()
+                .follower(tester1)
+                .followee(tester2)
+                .build();
+        followRepository.save(follow);
+
+        // when
+        followService.respondToFollowRequest(follow.getId(), false);
+
+        // then
+        assertThat(followRepository.findAll())
+                .hasSize(1)
+                .first()
+                .extracting("follower", "followee", "status")
+                .containsExactly(tester1, tester2, REJECTED);
+    }
+
+    @Test
+    @DisplayName("언팔로우")
+    void unfollow() {
+        // given
+        Member tester1 = createMember("tester1");
+        Member tester2 = createMember("tester2");
+        Follow follow = Follow.builder()
+                .follower(tester1)
+                .followee(tester2)
+                .build();
+        follow.updateStatus(ACCEPTED);
+        followRepository.save(follow);
+
+        // when
+        followService.unfollow(tester1.getId(), tester2.getId());
+
+        // then
+        assertThat(followRepository.findById(follow.getId())).isEmpty();
+    }
+
+    private Member createMember(String username) {
+        Member member = Member.builder()
+                .username(username)
+                .email(username + "@test.com")
+                .provider(OAuth2Provider.GOOGLE)
+                .providerId("google_" + username)
+                .role(Role.ROLE_USER)
+                .profileImageUrl("profileImageUrl")
+                .build();
+        member.initDiligence();
+        return memberRepository.save(member);
+    }
+
+}

--- a/src/test/java/com/maruhxn/todomon/domain/social/application/OverallRankQueryServiceTest.java
+++ b/src/test/java/com/maruhxn/todomon/domain/social/application/OverallRankQueryServiceTest.java
@@ -1,0 +1,299 @@
+package com.maruhxn.todomon.domain.social.application;
+
+import com.maruhxn.todomon.domain.member.dao.MemberRepository;
+import com.maruhxn.todomon.domain.member.domain.Member;
+import com.maruhxn.todomon.domain.pet.domain.CollectedPet;
+import com.maruhxn.todomon.domain.pet.domain.Pet;
+import com.maruhxn.todomon.domain.pet.domain.PetType;
+import com.maruhxn.todomon.domain.pet.domain.Rarity;
+import com.maruhxn.todomon.domain.social.dto.response.CollectedPetRankItem;
+import com.maruhxn.todomon.domain.social.dto.response.DiligenceRankItem;
+import com.maruhxn.todomon.domain.social.dto.response.TodoAchievementRankItem;
+import com.maruhxn.todomon.domain.todo.dao.TodoAchievementHistoryRepository;
+import com.maruhxn.todomon.domain.todo.dao.TodoRepository;
+import com.maruhxn.todomon.domain.todo.domain.Todo;
+import com.maruhxn.todomon.domain.todo.domain.TodoAchievementHistory;
+import com.maruhxn.todomon.global.auth.model.Role;
+import com.maruhxn.todomon.global.auth.model.provider.OAuth2Provider;
+import com.maruhxn.todomon.util.IntegrationTestSupport;
+import com.maruhxn.todomon.util.TestTodoFactory;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import java.time.DayOfWeek;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.time.temporal.TemporalAdjusters;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.IntStream;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.tuple;
+
+@DisplayName("[Service] - OverallRankQueryService")
+class OverallRankQueryServiceTest extends IntegrationTestSupport {
+
+    @Autowired
+    TestTodoFactory testTodoFactory;
+
+    @Autowired
+    OverallRankQueryService overallRankQueryService;
+
+    @Autowired
+    MemberRepository memberRepository;
+
+    @Autowired
+    TodoRepository todoRepository;
+
+    @Autowired
+    TodoAchievementHistoryRepository todoAchievementHistoryRepository;
+
+    @Test
+    @DisplayName("일관성 레벨이 가장 높은 탑 10 유저를 조회한다. (게이지 -> 레벨 -> 가입일자 순)")
+    void getTop10MembersByDiligenceLevelAndGauge() {
+        // given
+        List<Member> members = createAndSaveMembers(20);
+        for (int i = 1; i <= 5; i++) { // tester2, tester4, tester6, tester8, tester10
+            Member member = members.get(2 * i - 1);
+            member.getDiligence().levelUp(2 * i);
+        }
+        memberRepository.saveAll(members);
+        // when
+        List<DiligenceRankItem> result = overallRankQueryService.getTop10MembersByDiligenceLevelAndGauge();
+        Member tester10 = members.get(9);
+        Member tester8 = members.get(7);
+        Member tester6 = members.get(5);
+        Member tester4 = members.get(3);
+        Member tester2 = members.get(1);
+        Member tester1 = members.get(0);
+        Member tester3 = members.get(2);
+        Member tester5 = members.get(4);
+        Member tester7 = members.get(6);
+        Member tester9 = members.get(8);
+
+        // then
+        assertThat(result)
+                .hasSize(10)
+                .extracting("id", "username", "profileImageUrl", "level")
+                .containsExactly(
+                        tuple(tester10.getId(), tester10.getUsername(), tester10.getProfileImageUrl(), tester10.getDiligence().getLevel()),
+                        tuple(tester8.getId(), tester8.getUsername(), tester8.getProfileImageUrl(), tester8.getDiligence().getLevel()),
+                        tuple(tester6.getId(), tester6.getUsername(), tester6.getProfileImageUrl(), tester6.getDiligence().getLevel()),
+                        tuple(tester4.getId(), tester4.getUsername(), tester4.getProfileImageUrl(), tester4.getDiligence().getLevel()),
+                        tuple(tester2.getId(), tester2.getUsername(), tester2.getProfileImageUrl(), tester2.getDiligence().getLevel()),
+                        tuple(tester1.getId(), tester1.getUsername(), tester1.getProfileImageUrl(), tester1.getDiligence().getLevel()),
+                        tuple(tester3.getId(), tester3.getUsername(), tester3.getProfileImageUrl(), tester3.getDiligence().getLevel()),
+                        tuple(tester5.getId(), tester5.getUsername(), tester5.getProfileImageUrl(), tester5.getDiligence().getLevel()),
+                        tuple(tester7.getId(), tester7.getUsername(), tester7.getProfileImageUrl(), tester7.getDiligence().getLevel()),
+                        tuple(tester9.getId(), tester9.getUsername(), tester9.getProfileImageUrl(), tester9.getDiligence().getLevel())
+                );
+    }
+
+    @Test
+    @DisplayName("가장 많은 펫을 획득한 탑 10 유저를 조회한다. (획득한 펫 수 -> 마지막 획득 일자 -> 가입일자 순)")
+    void getTop10MembersByCollectedPetCnt() {
+        // given
+        List<Member> members = createAndSaveMembers(20);
+        for (int i = 1; i <= 5; i++) { // tester2, tester4, tester6, tester8, tester10
+            Member member = members.get(2 * i - 1);
+            int petCnt = i % (PetType.values().length + 1);
+            createPets(member, petCnt == 0 ? 1 : petCnt); // 1 2 3 1 1
+        }
+
+        memberRepository.saveAll(members);
+
+        // when
+        List<CollectedPetRankItem> result = overallRankQueryService.getTop10MembersByCollectedPetCnt();
+        Member tester10 = members.get(9);
+        Member tester8 = members.get(7);
+        Member tester6 = members.get(5);
+        Member tester4 = members.get(3);
+        Member tester2 = members.get(1);
+        Member tester1 = members.get(0);
+        Member tester3 = members.get(2);
+        Member tester5 = members.get(4);
+        Member tester7 = members.get(6);
+        Member tester9 = members.get(8);
+
+        // then
+        assertThat(result)
+                .hasSize(10)
+                .extracting("id", "username", "profileImageUrl", "petCnt")
+                .containsExactly(
+                        tuple(tester6.getId(), tester6.getUsername(), tester6.getProfileImageUrl(), 3),
+                        tuple(tester4.getId(), tester4.getUsername(), tester4.getProfileImageUrl(), 2),
+                        tuple(tester10.getId(), tester10.getUsername(), tester10.getProfileImageUrl(), 1),
+                        tuple(tester8.getId(), tester8.getUsername(), tester8.getProfileImageUrl(), 1),
+                        tuple(tester2.getId(), tester2.getUsername(), tester2.getProfileImageUrl(), 1),
+                        tuple(tester1.getId(), tester1.getUsername(), tester1.getProfileImageUrl(), 0),
+                        tuple(tester3.getId(), tester3.getUsername(), tester3.getProfileImageUrl(), 0),
+                        tuple(tester5.getId(), tester5.getUsername(), tester5.getProfileImageUrl(), 0),
+                        tuple(tester7.getId(), tester7.getUsername(), tester7.getProfileImageUrl(), 0),
+                        tuple(tester9.getId(), tester9.getUsername(), tester9.getProfileImageUrl(), 0)
+                );
+    }
+
+    @Test
+    @DisplayName("전날 가장 많은 투두를 수행한 탑 10 유저를 조회한다.")
+    void getRankingOfDailyAchievement() {
+        // given
+        LocalDate yesterday = LocalDate.now().minusDays(1);
+        List<Member> members = createAndSaveMembers(12);
+        memberRepository.saveAll(members);
+        members.forEach(member -> {
+            List<Todo> todoList = createManySingleTodo(yesterday, member, 10);
+        });
+        // 투두 수행
+        for (int i = 1; i <= 5; i++) { // tester2, tester4, tester6, tester8, tester10
+            Member member = members.get(2 * i - 1);
+            LocalDateTime startAt = yesterday.atStartOfDay();
+            LocalDateTime endAt = LocalDateTime.of(yesterday, LocalTime.of(23, 59, 59, 999999999));
+            List<Todo> todos = todoRepository.findSingleTodosByWriterIdAndDate(member.getId(), startAt, endAt);
+            // 각각 1, 2, 3, 4, 5개 수행
+            for (int j = 0; j < i; j++) {
+                Todo todo = todos.get(j);
+                todo.updateIsDone(true);
+            }
+            // 투두 수행 내역 저장
+            TodoAchievementHistory history = TodoAchievementHistory.builder()
+                    .member(member)
+                    .date(yesterday)
+                    .cnt((long) i)
+                    .build();
+
+            todoAchievementHistoryRepository.save(history);
+        }
+
+        // when
+        List<TodoAchievementRankItem> result = overallRankQueryService.getRankingOfDailyAchievement();
+        Member tester2 = members.get(1);
+        Member tester4 = members.get(3);
+        Member tester6 = members.get(5);
+        Member tester8 = members.get(7);
+        Member tester10 = members.get(9);
+
+        // then
+        assertThat(result)
+                .hasSize(5)
+                .extracting("id", "username", "profileImageUrl", "cnt")
+                .containsExactly(
+                        tuple(tester10.getId(), tester10.getUsername(), tester10.getProfileImageUrl(), 5L),
+                        tuple(tester8.getId(), tester8.getUsername(), tester8.getProfileImageUrl(), 4L),
+                        tuple(tester6.getId(), tester6.getUsername(), tester6.getProfileImageUrl(), 3L),
+                        tuple(tester4.getId(), tester4.getUsername(), tester4.getProfileImageUrl(), 2L),
+                        tuple(tester2.getId(), tester2.getUsername(), tester2.getProfileImageUrl(), 1L)
+                );
+    }
+
+    @Test
+    @DisplayName("지난 주 가장 많은 투두를 수행한 탑 10 유저를 조회한다.")
+    void getRankingOfWeeklyAchievement() {
+        LocalDate startOfCurrentWeek = LocalDate.now().with(TemporalAdjusters.previousOrSame(DayOfWeek.MONDAY));
+        LocalDate startOfLastWeek = startOfCurrentWeek.minusWeeks(1);
+        LocalDate endOfLastWeek = startOfCurrentWeek.minusDays(1);
+        List<Member> members = createAndSaveMembers(12);
+        memberRepository.saveAll(members);
+        members.forEach(member -> {
+            List<Todo> todos = new ArrayList<>();
+            for (int i = 0; i < 7; i++) {
+                Todo todo = getSingleAlldayTodo(startOfLastWeek.plusDays(i), member);
+                todos.add(todo);
+            }
+            todoRepository.saveAll(todos);
+        });
+        // 투두 수행
+        for (int i = 1; i <= 5; i++) { // tester2, tester4, tester6, tester8, tester10
+            Member member = members.get(2 * i - 1);
+            LocalDateTime startAt = startOfLastWeek.atStartOfDay();
+            LocalDateTime endAt = LocalDateTime.of(
+                    endOfLastWeek,
+                    LocalTime.of(23, 59, 59, 999999999)
+            );
+            List<Todo> todos = todoRepository.findSingleTodosByWriterIdAndDate(member.getId(), startAt, endAt);
+            // 각각 1, 2, 3, 4, 5개 수행
+            for (int j = 0; j < i; j++) {
+                Todo todo = todos.get(j);
+                todo.updateIsDone(true);
+                TodoAchievementHistory history = TodoAchievementHistory.builder()
+                        .member(member)
+                        .date(todo.getStartAt().toLocalDate())
+                        .cnt((long) i)
+                        .build();
+                todoAchievementHistoryRepository.save(history);
+            }
+
+        }
+
+        // when
+        List<TodoAchievementRankItem> result = overallRankQueryService.getRankingOfWeeklyAchievement();
+        Member tester2 = members.get(1);
+        Member tester4 = members.get(3);
+        Member tester6 = members.get(5);
+        Member tester8 = members.get(7);
+        Member tester10 = members.get(9);
+
+        // then
+        assertThat(result)
+                .hasSize(5)
+                .extracting("id", "username", "profileImageUrl", "cnt")
+                .containsExactly(
+                        tuple(tester10.getId(), tester10.getUsername(), tester10.getProfileImageUrl(), 5L),
+                        tuple(tester8.getId(), tester8.getUsername(), tester8.getProfileImageUrl(), 4L),
+                        tuple(tester6.getId(), tester6.getUsername(), tester6.getProfileImageUrl(), 3L),
+                        tuple(tester4.getId(), tester4.getUsername(), tester4.getProfileImageUrl(), 2L),
+                        tuple(tester2.getId(), tester2.getUsername(), tester2.getProfileImageUrl(), 1L)
+                );
+    }
+
+    private List<Todo> createManySingleTodo(LocalDate date, Member member, int cnt) {
+        return IntStream.rangeClosed(0, cnt)
+                .mapToObj(i -> getSingleAlldayTodo(date, member)
+                ).toList();
+    }
+
+    private Todo getSingleAlldayTodo(LocalDate date, Member member) {
+        return testTodoFactory.createSingleTodo(
+                date.atStartOfDay(),
+                date.atStartOfDay(),
+                true,
+                member);
+    }
+
+    private List<Member> createAndSaveMembers(int count) {
+        return IntStream.rangeClosed(1, count)
+                .mapToObj(this::createMember)
+                .toList();
+    }
+
+    private void createPets(Member member, int cnt) {
+        IntStream.rangeClosed(0, cnt - 1)
+                .forEach(i -> {
+                    Pet pet = Pet.builder()
+                            .petType(PetType.values()[i])
+                            .rarity(Rarity.COMMON)
+                            .build();
+                    member.addPet(pet);
+
+                    CollectedPet collectedPet = CollectedPet.of(pet);
+                    member.addCollection(collectedPet);
+                });
+    }
+
+    private Member createMember(int index) {
+        String username = "tester" + index;
+        Member member = Member.builder()
+                .username(username)
+                .email(username + "@test.com")
+                .provider(OAuth2Provider.GOOGLE)
+                .providerId("google_" + username)
+                .role(Role.ROLE_USER)
+                .profileImageUrl("profileImageUrl")
+                .build();
+        member.initDiligence();
+        return member;
+    }
+
+}

--- a/src/test/java/com/maruhxn/todomon/domain/social/application/SocialRankQueryServiceTest.java
+++ b/src/test/java/com/maruhxn/todomon/domain/social/application/SocialRankQueryServiceTest.java
@@ -1,0 +1,369 @@
+package com.maruhxn.todomon.domain.social.application;
+
+import com.maruhxn.todomon.domain.member.dao.MemberRepository;
+import com.maruhxn.todomon.domain.member.domain.Member;
+import com.maruhxn.todomon.domain.pet.domain.CollectedPet;
+import com.maruhxn.todomon.domain.pet.domain.Pet;
+import com.maruhxn.todomon.domain.pet.domain.PetType;
+import com.maruhxn.todomon.domain.pet.domain.Rarity;
+import com.maruhxn.todomon.domain.social.dao.FollowRepository;
+import com.maruhxn.todomon.domain.social.domain.Follow;
+import com.maruhxn.todomon.domain.social.domain.FollowRequestStatus;
+import com.maruhxn.todomon.domain.social.dto.response.CollectedPetRankItem;
+import com.maruhxn.todomon.domain.social.dto.response.DiligenceRankItem;
+import com.maruhxn.todomon.domain.social.dto.response.TodoAchievementRankItem;
+import com.maruhxn.todomon.domain.todo.dao.TodoAchievementHistoryRepository;
+import com.maruhxn.todomon.domain.todo.dao.TodoRepository;
+import com.maruhxn.todomon.domain.todo.domain.Todo;
+import com.maruhxn.todomon.domain.todo.domain.TodoAchievementHistory;
+import com.maruhxn.todomon.global.auth.model.Role;
+import com.maruhxn.todomon.global.auth.model.provider.OAuth2Provider;
+import com.maruhxn.todomon.util.IntegrationTestSupport;
+import com.maruhxn.todomon.util.TestTodoFactory;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import java.time.DayOfWeek;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.time.temporal.TemporalAdjusters;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.IntStream;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.tuple;
+
+@DisplayName("[Service] - SocialRankQueryService")
+class SocialRankQueryServiceTest extends IntegrationTestSupport {
+
+    @Autowired
+    TestTodoFactory testTodoFactory;
+
+    @Autowired
+    SocialRankQueryService socialRankQueryService;
+
+    @Autowired
+    MemberRepository memberRepository;
+
+    @Autowired
+    TodoRepository todoRepository;
+
+    @Autowired
+    TodoAchievementHistoryRepository todoAchievementHistoryRepository;
+
+    @Autowired
+    FollowRepository followRepository;
+
+    @Test
+    @DisplayName("팔로우 한 유저(자신 포함) 중 일관성 레벨이 가장 높은 탑 10 유저를 조회한다. (게이지 -> 레벨 -> 가입일자 순)")
+    void getSocialRankingOfDiligence() {
+        // given
+        List<Member> members = createAndSaveMembers(20);
+        Member currentMember = members.get(0);
+        // 일관성 레벨 작업
+        for (int i = 1; i <= 5; i++) { // tester2, tester4, tester6, tester8, tester10
+            Member member = members.get(2 * i - 1);
+            member.getDiligence().levelUp(2 * i);
+        }
+        memberRepository.saveAll(members);
+
+        // 팔로우 작업
+        for (int i = 1; i <= 10; i++) {
+            Follow follow = Follow.builder()
+                    .follower(currentMember)
+                    .followee(members.get(i))
+                    .build();
+            follow.updateStatus(FollowRequestStatus.ACCEPTED);
+            followRepository.save(follow);
+        }
+
+        // when
+        List<DiligenceRankItem> result = socialRankQueryService.getSocialRankingOfDiligence(currentMember);
+        Member tester10 = members.get(9);
+        Member tester8 = members.get(7);
+        Member tester6 = members.get(5);
+        Member tester4 = members.get(3);
+        Member tester2 = members.get(1);
+        Member tester3 = members.get(2);
+        Member tester5 = members.get(4);
+        Member tester7 = members.get(6);
+        Member tester9 = members.get(8);
+
+        // then
+        assertThat(result)
+                .hasSize(10)
+                .extracting("id", "username", "profileImageUrl", "level")
+                .containsExactly(
+                        tuple(tester10.getId(), tester10.getUsername(), tester10.getProfileImageUrl(), tester10.getDiligence().getLevel()),
+                        tuple(tester8.getId(), tester8.getUsername(), tester8.getProfileImageUrl(), tester8.getDiligence().getLevel()),
+                        tuple(tester6.getId(), tester6.getUsername(), tester6.getProfileImageUrl(), tester6.getDiligence().getLevel()),
+                        tuple(tester4.getId(), tester4.getUsername(), tester4.getProfileImageUrl(), tester4.getDiligence().getLevel()),
+                        tuple(tester2.getId(), tester2.getUsername(), tester2.getProfileImageUrl(), tester2.getDiligence().getLevel()),
+                        tuple(currentMember.getId(), currentMember.getUsername(), currentMember.getProfileImageUrl(), currentMember.getDiligence().getLevel()),
+                        tuple(tester3.getId(), tester3.getUsername(), tester3.getProfileImageUrl(), tester3.getDiligence().getLevel()),
+                        tuple(tester5.getId(), tester5.getUsername(), tester5.getProfileImageUrl(), tester5.getDiligence().getLevel()),
+                        tuple(tester7.getId(), tester7.getUsername(), tester7.getProfileImageUrl(), tester7.getDiligence().getLevel()),
+                        tuple(tester9.getId(), tester9.getUsername(), tester9.getProfileImageUrl(), tester9.getDiligence().getLevel())
+                );
+    }
+
+    @Test
+    @DisplayName("팔로우 한 유저(자신 포함) 중 가장 많은 펫을 획득한 탑 10 유저를 조회한다. (획득한 펫 수 -> 마지막 획득 일자 -> 가입일자 순)")
+    void getSocialRankingOfCollection() {
+        // given
+        List<Member> members = createAndSaveMembers(20);
+        Member currentMember = members.get(0);
+        // 펫 생성 작업
+        for (int i = 1; i <= 5; i++) { // tester2, tester4, tester6, tester8, tester10
+            Member member = members.get(2 * i - 1);
+            int petCnt = i % (PetType.values().length + 1);
+            createPets(member, petCnt == 0 ? 1 : petCnt); // 1 2 3 1 1
+        }
+        memberRepository.saveAll(members);
+
+        // 팔로우 작업
+        for (int i = 1; i <= 10; i++) {
+            Follow follow = Follow.builder()
+                    .follower(currentMember)
+                    .followee(members.get(i))
+                    .build();
+            follow.updateStatus(FollowRequestStatus.ACCEPTED);
+            followRepository.save(follow);
+        }
+
+        // when
+        List<CollectedPetRankItem> result = socialRankQueryService.getSocialRankingOfCollection(currentMember);
+        Member tester10 = members.get(9);
+        Member tester8 = members.get(7);
+        Member tester6 = members.get(5);
+        Member tester4 = members.get(3);
+        Member tester2 = members.get(1);
+        Member tester3 = members.get(2);
+        Member tester5 = members.get(4);
+        Member tester7 = members.get(6);
+        Member tester9 = members.get(8);
+
+        // then
+        assertThat(result)
+                .hasSize(10)
+                .extracting("id", "username", "profileImageUrl", "petCnt")
+                .containsExactly(
+                        tuple(tester6.getId(), tester6.getUsername(), tester6.getProfileImageUrl(), 3),
+                        tuple(tester4.getId(), tester4.getUsername(), tester4.getProfileImageUrl(), 2),
+                        tuple(tester10.getId(), tester10.getUsername(), tester10.getProfileImageUrl(), 1),
+                        tuple(tester8.getId(), tester8.getUsername(), tester8.getProfileImageUrl(), 1),
+                        tuple(tester2.getId(), tester2.getUsername(), tester2.getProfileImageUrl(), 1),
+                        tuple(currentMember.getId(), currentMember.getUsername(), currentMember.getProfileImageUrl(), 0),
+                        tuple(tester3.getId(), tester3.getUsername(), tester3.getProfileImageUrl(), 0),
+                        tuple(tester5.getId(), tester5.getUsername(), tester5.getProfileImageUrl(), 0),
+                        tuple(tester7.getId(), tester7.getUsername(), tester7.getProfileImageUrl(), 0),
+                        tuple(tester9.getId(), tester9.getUsername(), tester9.getProfileImageUrl(), 0)
+                );
+    }
+
+    @Test
+    @DisplayName("팔로우 한 유저(자신 포함) 중 전날 가장 많은 투두를 수행한 탑 10 유저를 조회한다.")
+    void getSocialRankingOfDailyAchievement() {
+        // given
+        LocalDate yesterday = LocalDate.now().minusDays(1);
+        List<Member> members = createAndSaveMembers(20);
+        Member currentMember = members.get(0);
+
+        memberRepository.saveAll(members);
+
+        // 투두 생성 작업
+        members.forEach(member -> {
+            List<Todo> todoList = createManySingleTodo(yesterday, member, 10);
+        });
+
+        // 팔로우 작업
+        for (int i = 1; i <= 10; i++) {
+            Follow follow = Follow.builder()
+                    .follower(currentMember)
+                    .followee(members.get(i))
+                    .build();
+            follow.updateStatus(FollowRequestStatus.ACCEPTED);
+            followRepository.save(follow);
+        }
+
+
+        // 투두 수행
+        for (int i = 1; i <= 5; i++) { // tester2, tester4, tester6, tester8, tester10
+            Member member = members.get(2 * i - 1);
+            LocalDateTime startAt = yesterday.atStartOfDay();
+            LocalDateTime endAt = LocalDateTime.of(yesterday, LocalTime.of(23, 59, 59, 999999999));
+            List<Todo> todos = todoRepository.findSingleTodosByWriterIdAndDate(member.getId(), startAt, endAt);
+            // 각각 1, 2, 3, 4, 5개 수행
+            for (int j = 0; j < i; j++) {
+                Todo todo = todos.get(j);
+                todo.updateIsDone(true);
+            }
+            // 투두 수행 내역 저장
+            TodoAchievementHistory history = TodoAchievementHistory.builder()
+                    .member(member)
+                    .date(yesterday)
+                    .cnt((long) i)
+                    .build();
+
+            todoAchievementHistoryRepository.save(history);
+        }
+
+        // when
+        List<TodoAchievementRankItem> result = socialRankQueryService.getSocialRankingOfDailyAchievement(currentMember);
+        Member tester2 = members.get(1);
+        Member tester4 = members.get(3);
+        Member tester6 = members.get(5);
+        Member tester8 = members.get(7);
+        Member tester10 = members.get(9);
+
+        // then
+        assertThat(result)
+                .hasSize(5)
+                .extracting("id", "username", "profileImageUrl", "cnt")
+                .containsExactly(
+                        tuple(tester10.getId(), tester10.getUsername(), tester10.getProfileImageUrl(), 5L),
+                        tuple(tester8.getId(), tester8.getUsername(), tester8.getProfileImageUrl(), 4L),
+                        tuple(tester6.getId(), tester6.getUsername(), tester6.getProfileImageUrl(), 3L),
+                        tuple(tester4.getId(), tester4.getUsername(), tester4.getProfileImageUrl(), 2L),
+                        tuple(tester2.getId(), tester2.getUsername(), tester2.getProfileImageUrl(), 1L)
+                );
+    }
+
+    @Test
+    @DisplayName("팔로우 한 유저(자신 포함) 중 지난 주 가장 많은 투두를 수행한 탑 10 유저를 조회한다.")
+    void getSocialRankingOfWeeklyAchievement() {
+        LocalDate startOfCurrentWeek = LocalDate.now().with(TemporalAdjusters.previousOrSame(DayOfWeek.MONDAY));
+        LocalDate startOfLastWeek = startOfCurrentWeek.minusWeeks(1);
+        LocalDate endOfLastWeek = startOfCurrentWeek.minusDays(1);
+        List<Member> members = createAndSaveMembers(20);
+        memberRepository.saveAll(members);
+        Member currentMember = members.get(0);
+
+        // 투두 생성 작업
+        members.forEach(member -> {
+            List<Todo> todos = new ArrayList<>();
+            for (int i = 0; i < 7; i++) {
+                Todo todo = getSingleAlldayTodo(startOfLastWeek.plusDays(i), member);
+                todos.add(todo);
+            }
+            todoRepository.saveAll(todos);
+        });
+
+        // 팔로우 작업
+        for (int i = 1; i <= 10; i++) {
+            Follow follow = Follow.builder()
+                    .follower(currentMember)
+                    .followee(members.get(i))
+                    .build();
+            follow.updateStatus(FollowRequestStatus.ACCEPTED);
+            followRepository.save(follow);
+        }
+
+        // 투두 수행
+        for (int i = 0; i <= 5; i++) { // tester2, tester4, tester6, tester8, tester10
+            int index = 2 * i - 1;
+            Member member = members.get(Math.max(index, 0));
+            LocalDateTime startAt = startOfLastWeek.atStartOfDay();
+            LocalDateTime endAt = LocalDateTime.of(
+                    endOfLastWeek,
+                    LocalTime.of(23, 59, 59, 999999999)
+            );
+            List<Todo> todos = todoRepository.findSingleTodosByWriterIdAndDate(member.getId(), startAt, endAt);
+            // 각각 1, 1, 2, 3, 4, 5개 수행
+            if (i == 0) {
+                Todo todo = todos.get(0);
+                todo.updateIsDone(true);
+                TodoAchievementHistory history = TodoAchievementHistory.builder()
+                        .member(member)
+                        .date(todo.getStartAt().toLocalDate())
+                        .cnt(1L)
+                        .build();
+                todoAchievementHistoryRepository.save(history);
+            } else {
+                for (int j = 0; j < i; j++) {
+                    Todo todo = todos.get(j);
+                    todo.updateIsDone(true);
+                    TodoAchievementHistory history = TodoAchievementHistory.builder()
+                            .member(member)
+                            .date(todo.getStartAt().toLocalDate())
+                            .cnt((long) i)
+                            .build();
+                    todoAchievementHistoryRepository.save(history);
+                }
+            }
+
+        }
+
+        // when
+        List<TodoAchievementRankItem> result = socialRankQueryService.getSocialRankingOfWeeklyAchievement(currentMember);
+        Member tester2 = members.get(1);
+        Member tester4 = members.get(3);
+        Member tester6 = members.get(5);
+        Member tester8 = members.get(7);
+        Member tester10 = members.get(9);
+
+        // then
+        assertThat(result)
+                .hasSize(6)
+                .extracting("id", "username", "profileImageUrl", "cnt")
+                .containsExactly(
+                        tuple(tester10.getId(), tester10.getUsername(), tester10.getProfileImageUrl(), 5L),
+                        tuple(tester8.getId(), tester8.getUsername(), tester8.getProfileImageUrl(), 4L),
+                        tuple(tester6.getId(), tester6.getUsername(), tester6.getProfileImageUrl(), 3L),
+                        tuple(tester4.getId(), tester4.getUsername(), tester4.getProfileImageUrl(), 2L),
+                        tuple(currentMember.getId(), currentMember.getUsername(), currentMember.getProfileImageUrl(), 1L),
+                        tuple(tester2.getId(), tester2.getUsername(), tester2.getProfileImageUrl(), 1L)
+                );
+    }
+
+    private List<Todo> createManySingleTodo(LocalDate date, Member member, int cnt) {
+        return IntStream.rangeClosed(0, cnt)
+                .mapToObj(i -> getSingleAlldayTodo(date, member)
+                ).toList();
+    }
+
+    private Todo getSingleAlldayTodo(LocalDate date, Member member) {
+        return testTodoFactory.createSingleTodo(
+                date.atStartOfDay(),
+                date.atStartOfDay(),
+                true,
+                member);
+    }
+
+    private List<Member> createAndSaveMembers(int count) {
+        return IntStream.rangeClosed(1, count)
+                .mapToObj(this::createMember)
+                .toList();
+    }
+
+    private void createPets(Member member, int cnt) {
+        IntStream.rangeClosed(0, cnt - 1)
+                .forEach(i -> {
+                    Pet pet = Pet.builder()
+                            .petType(PetType.values()[i])
+                            .rarity(Rarity.COMMON)
+                            .build();
+                    member.addPet(pet);
+
+                    CollectedPet collectedPet = CollectedPet.of(pet);
+                    member.addCollection(collectedPet);
+                });
+    }
+
+    private Member createMember(int index) {
+        String username = "tester" + index;
+        Member member = Member.builder()
+                .username(username)
+                .email(username + "@test.com")
+                .provider(OAuth2Provider.GOOGLE)
+                .providerId("google_" + username)
+                .role(Role.ROLE_USER)
+                .profileImageUrl("profileImageUrl")
+                .build();
+        member.initDiligence();
+        return member;
+    }
+}

--- a/src/test/java/com/maruhxn/todomon/domain/social/application/StarServiceTest.java
+++ b/src/test/java/com/maruhxn/todomon/domain/social/application/StarServiceTest.java
@@ -1,0 +1,177 @@
+package com.maruhxn.todomon.domain.social.application;
+
+import com.maruhxn.todomon.domain.member.dao.MemberRepository;
+import com.maruhxn.todomon.domain.member.domain.Member;
+import com.maruhxn.todomon.domain.social.dao.FollowRepository;
+import com.maruhxn.todomon.domain.social.dao.StarTransactionRepository;
+import com.maruhxn.todomon.domain.social.domain.Follow;
+import com.maruhxn.todomon.domain.social.domain.FollowRequestStatus;
+import com.maruhxn.todomon.domain.social.domain.StarTransaction;
+import com.maruhxn.todomon.domain.social.domain.StarTransactionStatus;
+import com.maruhxn.todomon.global.auth.model.Role;
+import com.maruhxn.todomon.global.auth.model.provider.OAuth2Provider;
+import com.maruhxn.todomon.global.error.ErrorCode;
+import com.maruhxn.todomon.global.error.exception.BadRequestException;
+import com.maruhxn.todomon.global.error.exception.ForbiddenException;
+import com.maruhxn.todomon.util.IntegrationTestSupport;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+@DisplayName("[Service] - StarService")
+class StarServiceTest extends IntegrationTestSupport {
+
+    @Autowired
+    StarService starService;
+
+    @Autowired
+    MemberRepository memberRepository;
+
+    @Autowired
+    StarTransactionRepository starTransactionRepository;
+
+    @Autowired
+    FollowRepository followRepository;
+
+    @Test
+    @DisplayName("팔로우 중인 유저에게 ⭐️을 보낼 수 있다.")
+    void sendStar() {
+        Member tester1 = createMember("tester1");
+        Member tester2 = createMember("tester2");
+        Follow follow = Follow.builder()
+                .follower(tester1)
+                .followee(tester2)
+                .build();
+        follow.updateStatus(FollowRequestStatus.ACCEPTED);
+        followRepository.save(follow);
+
+        // when
+        starService.sendStar(tester1, tester2.getId());
+
+        // then
+        assertThat(starTransactionRepository.findAll())
+                .hasSize(1)
+                .first()
+                .extracting("sender", "receiver", "status")
+                .containsExactly(tester1, tester2, StarTransactionStatus.SENT);
+    }
+
+    @Test
+    @DisplayName("맞팔로우 중이지 않은 유저에게는 ⭐️을 보낼 수 없다.")
+    void sendStarFailByForbidden() {
+        Member tester1 = createMember("tester1");
+        Member tester2 = createMember("tester2");
+        Follow follow = Follow.builder()
+                .follower(tester1)
+                .followee(tester2)
+                .build();
+        followRepository.save(follow);
+        // when / then
+        assertThatThrownBy(() -> starService.sendStar(tester1, tester2.getId()))
+                .isInstanceOf(ForbiddenException.class)
+                .hasMessage(ErrorCode.NOT_ACCEPTED_FOLLOW.getMessage());
+    }
+
+    @Test
+    @DisplayName("전달받은 ⭐️을 받는다.")
+    void receiveOneStar() {
+        // given
+        Member tester1 = createMember("tester1");
+        Member tester2 = createMember("tester2");
+        Follow follow = Follow.builder()
+                .follower(tester1)
+                .followee(tester2)
+                .build();
+        follow.updateStatus(FollowRequestStatus.ACCEPTED);
+        followRepository.save(follow);
+
+        StarTransaction transaction = StarTransaction.createTransaction(tester1, tester2);
+        starTransactionRepository.save(transaction);
+
+        // when
+        starService.receiveOneStar(tester2, transaction.getId());
+
+        // then
+        assertThat(transaction.getStatus()).isEqualTo(StarTransactionStatus.RECEIVED);
+        assertThat(tester2.getStarPoint()).isEqualTo(1);
+    }
+
+    @Test
+    @DisplayName("이미 받은 ⭐️을 다시 받을 수 없다.")
+    void receiveOneStarFail() {
+        // given
+        Member tester1 = createMember("tester1");
+        Member tester2 = createMember("tester2");
+        Follow follow = Follow.builder()
+                .follower(tester1)
+                .followee(tester2)
+                .build();
+        follow.updateStatus(FollowRequestStatus.ACCEPTED);
+        followRepository.save(follow);
+
+        StarTransaction transaction = StarTransaction.createTransaction(tester1, tester2);
+        transaction.updateStatus(StarTransactionStatus.RECEIVED);
+        starTransactionRepository.save(transaction);
+
+        // when
+        assertThatThrownBy(() -> starService.receiveOneStar(tester2, transaction.getId()))
+                .isInstanceOf(BadRequestException.class)
+                .hasMessage(ErrorCode.ALREADY_RECEIVED.getMessage());
+    }
+
+    @Test
+    @DisplayName("전달받은 모든 ⭐️을 한번에 받는다.")
+    void receiveAllStars() {
+        // given
+        Member tester1 = createMember("tester1");
+        Member tester2 = createMember("tester2");
+        Member tester3 = createMember("tester3");
+        Member tester4 = createMember("tester4");
+        Follow follow1 = Follow.builder()
+                .follower(tester2)
+                .followee(tester1)
+                .build();
+        Follow follow2 = Follow.builder()
+                .follower(tester3)
+                .followee(tester1)
+                .build();
+        Follow follow3 = Follow.builder()
+                .follower(tester4)
+                .followee(tester1)
+                .build();
+        follow1.updateStatus(FollowRequestStatus.ACCEPTED);
+        follow2.updateStatus(FollowRequestStatus.ACCEPTED);
+        follow3.updateStatus(FollowRequestStatus.ACCEPTED);
+        followRepository.saveAll(List.of(follow1, follow2, follow3));
+
+        StarTransaction transaction1 = StarTransaction.createTransaction(tester2, tester1);
+        StarTransaction transaction2 = StarTransaction.createTransaction(tester3, tester1);
+        StarTransaction transaction3 = StarTransaction.createTransaction(tester4, tester1);
+        transaction1.updateStatus(StarTransactionStatus.RECEIVED);
+        starTransactionRepository.saveAll(List.of(transaction1, transaction2, transaction3));
+
+        // when
+        starService.receiveAllStars(tester1);
+
+        // then
+        assertThat(tester1.getStarPoint()).isEqualTo(2);
+    }
+
+    private Member createMember(String username) {
+        Member member = Member.builder()
+                .username(username)
+                .email(username + "@test.com")
+                .provider(OAuth2Provider.GOOGLE)
+                .providerId("google_" + username)
+                .role(Role.ROLE_USER)
+                .profileImageUrl("profileImageUrl")
+                .build();
+        member.initDiligence();
+        return memberRepository.save(member);
+    }
+}

--- a/src/test/java/com/maruhxn/todomon/global/schedule/ScheduleServiceTest.java
+++ b/src/test/java/com/maruhxn/todomon/global/schedule/ScheduleServiceTest.java
@@ -1,0 +1,78 @@
+package com.maruhxn.todomon.global.schedule;
+
+import com.maruhxn.todomon.domain.member.dao.MemberRepository;
+import com.maruhxn.todomon.domain.member.domain.Member;
+import com.maruhxn.todomon.domain.todo.dao.TodoAchievementHistoryRepository;
+import com.maruhxn.todomon.domain.todo.domain.TodoAchievementHistory;
+import com.maruhxn.todomon.global.auth.model.Role;
+import com.maruhxn.todomon.global.auth.model.provider.OAuth2Provider;
+import com.maruhxn.todomon.util.IntegrationTestSupport;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import java.time.LocalDate;
+import java.util.List;
+import java.util.stream.IntStream;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.tuple;
+import static org.junit.jupiter.api.Assertions.*;
+
+@DisplayName("[Service] - ScheduleService")
+class ScheduleServiceTest extends IntegrationTestSupport {
+
+    @Autowired
+    ScheduleService scheduleService;
+
+    @Autowired
+    MemberRepository memberRepository;
+
+    @Autowired
+    TodoAchievementHistoryRepository todoAchievementHistoryRepository;
+
+    @Test
+    @DisplayName("매일 오전 00시에 모든 유저들의 전날 투두 수행 수를 저장한다.")
+    void saveDailyAchievementAndReset() {
+        // given
+        Member member1 = createMember(1);
+        Member member2 = createMember(2);
+        Member member3 = createMember(3);
+
+        member1.addDailyAchievementCnt(1);
+        member2.addDailyAchievementCnt(2);
+        member3.addDailyAchievementCnt(3);
+
+        memberRepository.saveAll(List.of(member1, member2, member3));
+
+        // when
+        scheduleService.saveDailyAchievementAndReset();
+
+        // then
+        LocalDate yesterday = LocalDate.now().minusDays(1);
+        List<TodoAchievementHistory> histories = todoAchievementHistoryRepository.findAll();
+
+        assertThat(histories)
+                .hasSize(3)
+                .extracting("member", "cnt", "date")
+                .containsExactlyInAnyOrder(
+                        tuple(member1, 1L, yesterday),
+                        tuple(member2, 2L, yesterday),
+                        tuple(member3, 3L, yesterday)
+                );
+    }
+
+    private Member createMember(int index) {
+        String username = "tester" + index;
+        Member member = Member.builder()
+                .username(username)
+                .email(username + "@test.com")
+                .provider(OAuth2Provider.GOOGLE)
+                .providerId("google_" + username)
+                .role(Role.ROLE_USER)
+                .profileImageUrl("profileImageUrl")
+                .build();
+        member.initDiligence();
+        return member;
+    }
+}


### PR DESCRIPTION
- 전체 랭킹 조회 기능
  - 일관성 레벨 Top 10
  - 획득한 펫 수 Top 10
  - 일간 투두 수행 수 Top 10
  - 주간 투두 수행 수 Top 10
- 팔로우 한 유저 랭킹 조회 기능
  - 일관성 레벨 Top 10
  - 획득한 펫 수 Top 10
  - 일간 투두 수행 수 Top 10
  - 주간 투두 수행 수 Top 10

- 매일 오전 12시에 일간 투두 수행 수 확인 후 반영하는 스케줄 작업 추가

This closes #6 .